### PR TITLE
Rebind local-project-directories when using local quicklisp.

### DIFF
--- a/src/util.lisp
+++ b/src/util.lisp
@@ -58,6 +58,8 @@
 
   (let (#+quicklisp
         (ql:*quicklisp-home* qlhome)
+        #+quicklisp
+        (ql:*local-project-directories* (list (merge-pathnames #P"local-projects/" qlhome)))
         (asdf::*source-registry* (make-hash-table :test 'equal))
         (asdf::*default-source-registries*
           '(asdf::environment-source-registry


### PR DESCRIPTION
This helps prevent outside systems from leaking in through the non-local quicklisp local-projects. It also opens up some interesting possibilities to allow git repos to be checked out directly to the local quicklisp's local-projects folder if someone wants to hack on them.