### PR TITLE
Parse dependency qlfiles on install and update

### DIFF
--- a/src/error.lisp
+++ b/src/error.lisp
@@ -2,9 +2,12 @@
 (defpackage qlot.error
   (:use :cl)
   (:export :qlot-error
-           :qlot-qlfile-error))
+           :qlot-qlfile-error
+           :qlot-sources-incompatible))
 (in-package :qlot.error)
 
 (define-condition qlot-error (simple-error) ())
 
 (define-condition qlot-qlfile-error (qlot-error) ())
+
+(define-condition qlot-sources-incompatible (qlot-error) ())

--- a/src/install.lisp
+++ b/src/install.lisp
@@ -194,9 +194,9 @@
           (update-in-place dist new-dist))))))
 
 (defun apply-qlfile-to-qlhome (file qlhome &key ignore-lock)
-  (let ((*tmp-directory* (fad:pathname-as-directory (merge-pathnames (fad::generate-random-string)
-                                                                     (merge-pathnames #P"tmp/qlot/" qlhome))))
-        (all-sources (prepare-qlfile file :ignore-lock ignore-lock)))
+  (let* ((*tmp-directory* (fad:pathname-as-directory (merge-pathnames (fad::generate-random-string)
+                                                                      (merge-pathnames #P"tmp/qlot/" qlhome))))
+         (all-sources (prepare-qlfile file :ignore-lock ignore-lock)))
 
     (start-server all-sources)
     (with-quicklisp-home qlhome

--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -6,6 +6,7 @@
                 :make-source
                 :find-source-class
                 :defrost-source
+                :prepare
                 :source-project-name
                 :source-version
                 :source-dist-name
@@ -101,4 +102,5 @@
       (setf sources
             (merging-lock-sources sources
                                   (parse-qlfile-lock lock-file))))
+    (mapc #'prepare sources)
     sources))

--- a/src/server.lisp
+++ b/src/server.lisp
@@ -3,7 +3,7 @@
   (:use :cl)
   (:import-from :qlot.source
                 :*dist-base-url*
-                :prepare
+                :package-source
                 :source-prepared
                 :url-path-for
                 :project.txt
@@ -75,7 +75,7 @@
         (setf (route app (url-path-for source 'project.txt))
               (lambda (params)
                 (let ((*tmp-directory* tmp-directory))
-                  (prepare source))
+                  (package-source source))
                 (dolist (action '(project.txt distinfo.txt releases.txt systems.txt archive))
                   (when-let ((path (url-path-for source action)))
                     (setf (route app path)

--- a/src/source.lisp
+++ b/src/source.lisp
@@ -26,6 +26,7 @@
            :source-direct-dependencies
            :find-source-class
            :prepare
+           :package-source
            :project-name
            :version
            :source-project-name
@@ -113,6 +114,13 @@
 
 (defmethod prepare :after (source)
   (setf (source-prepared source) t))
+
+(defgeneric package-source (source)
+  (:method ((source source))))
+
+(defmethod package-source :before ((source source))
+  (unless (source-prepared source)
+    (prepare source)))
 
 (defgeneric source-equal (source1 source2)
   (:method ((source1 t) (source2 t))

--- a/src/source.lisp
+++ b/src/source.lisp
@@ -35,6 +35,7 @@
            :source-prepared
            :source-defrost-args
            :source-equal
+           :source-compatible
            :project.txt
            :distinfo.txt
            :releases.txt
@@ -134,6 +135,9 @@
       (call-next-method)
       nil))
 
+(defgeneric source-compatible (source1 source2)
+  (:method ((source1 source) (source2 source))
+    (source-equal source1 source2)))
 
 ;;
 ;; Pages

--- a/src/source.lisp
+++ b/src/source.lisp
@@ -255,7 +255,8 @@ distinfo-subscription-url: ~A~A
                ((or (symbolp dep)
                     (stringp dep))
                 (string-downcase dep))
-               (error "Can't normalize dependency: ~S" dep))))
+               (t
+                (error "Can't normalize dependency: ~S" dep)))))
     (lambda (fun form env)
       (when (and (consp form)
                  (eq (car form) 'asdf:defsystem))

--- a/src/source/git.lisp
+++ b/src/source/git.lisp
@@ -73,6 +73,18 @@
        (equal (source-git-tag source1)
               (source-git-tag source2))))
 
+(defmethod source-compatible ((source1 source-git) (source2 source-git))
+  (and (string= (source-project-name source1)
+                (source-project-name source2))
+       (string= (source-git-remote-url source1)
+                (source-git-remote-url source2))
+       (or (equal (source-git-ref source1)
+                  (source-git-ref source2))
+           (equal (source-git-branch source1)
+                  (source-git-branch source2))
+           (equal (source-git-tag source1)
+                  (source-git-tag source2)))))
+
 (defmethod print-object ((source source-git) stream)
   (format stream "#<~S ~A ~A~:[~;~:* ~A~]>"
           (type-of source)

--- a/src/source/git.lisp
+++ b/src/source/git.lisp
@@ -55,8 +55,9 @@
         (pathname
          (format nil "~A-~A.tar.gz"
                  (source-project-name source)
-                 (source-version source))))
+                 (source-version source)))))
 
+(defmethod package-source ((source source-git))
   (create-tarball (source-directory source)
                   (source-archive source)))
 


### PR DESCRIPTION
This branch gets qlot to take qlfiles in (most) dependencies into account. It isn't quite ready for merging yet, but I'd like to open it now to see if there is feedback.

One remaining issue is deciding where the qlfiles are located. When running `qlot:install` or `qlot:update`, the qlfile for the system is determined using `asdf:component-pathname`, which requires the ASD file to be loaded and allows a toplevel `:pathname` argument in the `asdf:defsystem` to change where the qlfile is looked for. This seems suboptimal when looking for a dependency's qlfile as ASD files can contain aribtrary code other than the system definitions (grumble). This code instead assumes that dependency qlfiles are in the root of the directory, avoiding the need to load system definitions. If that's acceptable, install and update should probably be changed as well.

This also will not check any dependencies retrieved from Quicklisp for qlfiles, but that seems like correct behavior.

I'll also work on tests for this functionality. Do you have any of your publicly accessible projects that use qlfiles? Or should I make simple systems just for testing purposes?
