### PR TITLE
Support lispy ; comment in qlfile

### DIFF
--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -26,7 +26,7 @@
 
 (defun parse-qlfile-line (line)
   (labels ((trim-comment (line)
-             (ppcre:regex-replace "(?<!\\\\)#.*" line ""))
+             (ppcre:regex-replace "(?<!\\\\)[#|;].*" line ""))
            (canonical-line (line)
              (string-trim '(#\Space #\Tab)
                           (trim-comment line))))

--- a/t/parser.lisp
+++ b/t/parser.lisp
@@ -22,7 +22,7 @@
 (defun test-qlfile (name)
   (merge-pathnames name (asdf:system-relative-pathname :qlot #P"t/data/")))
 
-(plan 12)
+(plan 16)
 
 (diag "parse-qlfile-line")
 
@@ -42,10 +42,22 @@
           "invalid source")
 (is (parse-qlfile-line "# This is a comment.")
     nil
-    "comment")
+    "# comment")
 (is (parse-qlfile-line " # This is a comment.")
     nil
-    "comment")
+    " # comment")
+(is (parse-qlfile-line "; This is a comment.")
+    nil
+    "; comment")
+(is (parse-qlfile-line " ; This is a comment.")
+    nil
+    " ; comment")
+(is (parse-qlfile-line ";; This is a comment.")
+    nil
+    ";; comment")
+(is (parse-qlfile-line " ;; This is a comment.")
+    nil
+    " ;; comment")
 (is-type (parse-qlfile-line "git myapp http://myapp.com/\\#/myapp.git")
          'source-git
          "can escape a sharp")


### PR DESCRIPTION
For me it's more natural to use `;;` comments in the qlfile.

The old `#` comment still works.