### PR TITLE
Replace external-program with UIOP for windows compatibility.

### DIFF
--- a/qlot-install.asd
+++ b/qlot-install.asd
@@ -18,7 +18,7 @@
                :cl-fad
                :alexandria
                :cl-ppcre
-               :external-program
+               :uiop
                :usocket
                :split-sequence
                :iterate

--- a/src/shell.lisp
+++ b/src/shell.lisp
@@ -1,8 +1,6 @@
 (in-package :cl-user)
 (defpackage qlot.shell
   (:use :cl)
-  (:import-from :external-program
-                :run)
   (:export :safety-shell-command
            :shell-command-error))
 (in-package :qlot.shell)
@@ -24,13 +22,13 @@
 (defun safety-shell-command (program args)
   (with-output-to-string (stdout)
     (let ((stderr (make-string-output-stream)))
-      (multiple-value-bind (status code)
-          (external-program:run program args
-                                :output (make-broadcast-stream *standard-output*
-                                                               stdout)
-                                :error (make-broadcast-stream *error-output*
-                                                              stderr))
-        (declare (ignore status))
+      (multiple-value-bind (output error code)
+          (uiop:run-program (cons program args)
+                            :output (make-broadcast-stream *standard-output*
+                                                           stdout)
+                            :error (make-broadcast-stream *error-output*
+                                                          stderr))
+        (declare (ignore output error))
         (unless (zerop code)
           (error 'shell-command-error
                  :command (cons program args)


### PR DESCRIPTION
external-program uses /usr/bin/env to run external commands, which is obviously problematic on Windows. UIOP's RUN-PROGRAM is more portable, and looks like it does everything you need. I've tested this with a project of my own, and it was able to pull down all the various parts and QLOT:QUICKLOAD successfully.