### PR TITLE
Allow git to inherit the lisp's stdin for terminal detection.

### DIFF
--- a/src/shell.lisp
+++ b/src/shell.lisp
@@ -25,6 +25,7 @@
     (with-output-to-string (stderr)
       (multiple-value-bind (output error code)
           (uiop:run-program (cons program args)
+                            :input :interactive
                             :output (make-broadcast-stream *standard-output*
                                                            stdout)
                             :error-output stderr


### PR DESCRIPTION
When cloning via ssh, the ssh process that git starts needs to
prompt for a password, which requires a terminal or an ssh-askpass
program. When the input is not a terminal (the default) but ssh is
being run in a terminal session, ssh detects the following:
1) stdin is not a terminal, so we can't prompt there, but
2) there /is/ a controlling terminal for the process, so we
shouldn't use ssh-askpass to produce a graphical prompt.

This causes ssh to hang, and makes ssh-based git sources unusable
when running e.g. QLOT:INSTALL from an actual terminal. Using
:INPUT :INTERACTIVE allows ssh to use the terminal in terminal
sessions, and to use ssh-askpass when run from a non-terminal
(e.g. emacs).

Steps to reproduce the original issue:
1. Create a qlfile for an ssh git source, with an ssh-key that has a passphrase.
2. Attempt to QLOT:INSTALL it.
3. Watch ssh consume an entire cpu core.

I've verified that both ssh-askpass prompts (from slime/emacs) and
terminal-based prompts (from a terminal session) work correctly with this change,
including as part of a qlot install. SAFETY-SHELL-COMMAND is only used for git
commands, so I don't think the change should affect anything else.