### PR TITLE
Normalize source path to compute system file paths.

### DIFF
--- a/src/source.lisp
+++ b/src/source.lisp
@@ -297,9 +297,16 @@
                   (gethash (asdf:component-name system) *dependencies*))
           (asdf:clear-system system))))))
 
+(defun normalize-pathname (path)
+  "Return the pathname PATH resolved to a normalized pathname in the filesystem.
+Does not resolve symlinks, but PATH must actually exist in the filesystem."
+  (when (wild-pathname-p path)
+    (error "Wild pathnames cannot be normalized."))
+  (first (uiop:directory* path)))
+
 (defmethod releases.txt ((source source-has-directory))
   (let* ((tarball-file (source-archive source))
-         (source-dir (source-directory source))
+         (source-dir (normalize-pathname (source-directory source)))
          (prefix (car (last (pathname-directory source-dir)))))
     (multiple-value-bind (size file-md5 content-sha1)
         (with-open-file (in tarball-file :element-type '(unsigned-byte 8))


### PR DESCRIPTION
`UIOP:DIRECTORY-FILES` returns normalized pathnames,
but the source directory might have non-normal
components like '.' in it. If `ASDF:*CENTRAL-REGISTRY*`
contains a path like `#P"/foo/./"`, `DIRECTORY-FILES`
will return paths like `#P"/foo/bar.txt"`. Since the
length of the directory component differs, `SUBSEQ`
will wind up chopping characters off of the file
name, which causes all sorts of inscrutable errors
later.