### PR TITLE
Read only attrib

### DIFF
--- a/src/install.lisp
+++ b/src/install.lisp
@@ -264,8 +264,8 @@
                 do (format out "~&(~S .~% (~{~S ~S~^~%  ~}))~%" project-name contents)))))
 
     #+windows
-    (safety-shell-command 
-     "attrib" 
+    (safety-shell-command
+     "attrib"
      (list "-r" "-h" (format nil "~A*.*" (uiop:native-namestring *tmp-directory*)) "/s" "/d"))
     (uiop:delete-directory-tree *tmp-directory* :validate t :if-does-not-exist :ignore)))
 

--- a/src/install.lisp
+++ b/src/install.lisp
@@ -263,7 +263,7 @@
                 for (project-name . contents) = (freeze-source source)
                 do (format out "~&(~S .~% (~{~S ~S~^~%  ~}))~%" project-name contents)))))
 
-    #+(and windows ccl)
+    #+windows
     (safety-shell-command 
      "attrib" 
      (list "-r" "-h" (uiop:subpathname *tmp-directory* "*.*") "/s" "/d"))

--- a/src/install.lisp
+++ b/src/install.lisp
@@ -266,7 +266,7 @@
     #+windows
     (safety-shell-command 
      "attrib" 
-     (list "-r" "-h" (uiop:subpathname *tmp-directory* "*.*") "/s" "/d"))
+     (list "-r" "-h" (format nil "~A*.*" (uiop:native-namestring *tmp-directory*)) "/s" "/d"))
     (uiop:delete-directory-tree *tmp-directory* :validate t :if-does-not-exist :ignore)))
 
 (defgeneric install-project (object &rest args)


### PR DESCRIPTION
This PR fixes issues with read-only files on Windows under SBCL. #28 fixed the problem for CCL, but SBCL (and maybe others) have the same issue, so I've changed the feature check to just `#+windows`, since it shouldn't hurt lisps that don't strictly need it.

This branch also fixes an issue in the `attrib` call where `uiop:subpathname` was producing a non-wild pathname who namestring was the mangled `"^*.^*"` instead of `"*.*"` like you'd expect. I did it by converting the directory to a namestring and tacking on the wildcard with `format`, but if you weren't comfortable with that, there are other options:
1. Add an extra `#\\` character before the wildcard just in case -- we know this is windows, so we don't have to worry about which path separator to use.
2. Make wild pathname with `(make-pathname :name :wild :type :wild :defaults *tmp-directory*)`. That ought to have the right namestring. Probably.

Feel free to rebase this before merging if you've merged other fixes. I may have a few more on the way, and clean merge history is a wonderful thing.