### PR TITLE
Add capability to survive under proxy environment

### DIFF
--- a/qlot-install.asd
+++ b/qlot-install.asd
@@ -25,7 +25,7 @@
   :components ((:module "src"
                 :components
                 ((:file "parser" :depends-on ("source" "dist-sources" "error" "util"))
-                 (:file "install" :depends-on ("parser" "server" "tmp" "source" "shell" "util"))
+                 (:file "install" :depends-on ("parser" "server" "tmp" "source" "shell" "util" "proxy"))
                  (:file "server" :depends-on ("source" "parser" "tmp"))
                  (:file "shell")
                  (:file "tmp" :depends-on ("util"))
@@ -33,7 +33,7 @@
                  (:file "source" :depends-on ("tmp" "util"))
                  (:module "dist-sources"
                   :pathname "source"
-                  :depends-on ("source" "shell" "archive" "tmp" "util")
+                  :depends-on ("source" "shell" "archive" "tmp" "util" "proxy")
                   :serial t
                   :components
                   ((:file "ql")
@@ -41,5 +41,6 @@
                    (:file "http")
                    (:file "github")))
                  (:file "error")
-                 (:file "util"))))
+                 (:file "util")
+                 (:file "proxy"))))
   :in-order-to ((test-op (test-op qlot-test))))

--- a/src/proxy.lisp
+++ b/src/proxy.lisp
@@ -1,0 +1,29 @@
+(in-package :cl-user)
+(defpackage qlot.proxy
+  (:use :cl)
+  (:import-from :uiop
+                :getenvp)
+  (:export :get-proxy))
+(in-package :qlot.proxy)
+
+(defvar *proxy*
+  (let ((proxy (or (getenvp "http_proxy")
+                   (getenvp "HTTP_PROXY"))))
+    (and (not (string= "" proxy)) proxy)))
+
+(defun get-proxy ()
+  *proxy*)
+
+(progn
+  ;; dummy for suppress style warning
+  (defun orig-http-fetch ())
+  (setf (symbol-function 'orig-http-fetch) (fdefinition
+                                             (find-symbol (string :http-fetch) :ql-http)))
+  ;; do not use proxy if connect localhost
+  (setf (fdefinition (find-symbol (string :http-fetch) :ql-http))
+        (lambda (url &rest rest)
+          (let ((ql:*proxy-url*
+                  (if (ppcre:scan "^http://127\\.0\\.0\\.1" url)
+                    nil
+                    ql:*proxy-url*)))
+            (apply #'orig-http-fetch url rest)))))

--- a/src/source/github.lisp
+++ b/src/source/github.lisp
@@ -6,6 +6,8 @@
                 :source-http
                 :source-http-url
                 :url)
+  (:import-from :qlot.proxy
+                :get-proxy)
   (:import-from :yason
                 :parse)
   (:export :source-github
@@ -61,6 +63,7 @@
      (apply #'dex:get
             (format nil "https://api.github.com/repos/~A/~A" repos action)
             :want-stream t
+            :proxy (get-proxy)
             (if github-access-token
                 (list :basic-auth (cons github-access-token "x-oauth-basic"))
                 '())))))

--- a/src/source/http.lisp
+++ b/src/source/http.lisp
@@ -6,6 +6,8 @@
                 :tmp-path)
   (:import-from :qlot.archive
                 :extract-tarball)
+  (:import-from :qlot.proxy
+                :get-proxy)
   (:import-from :ironclad
                 :byte-array-to-hex-string
                 :digest-file)
@@ -47,7 +49,8 @@
          (format nil "~A.tar.gz" (source-project-name source))))
   (dex:fetch (source-http-url source)
              (source-archive source)
-             :if-exists :supersede)
+             :if-exists :supersede
+             :proxy (get-proxy))
   (setf (source-directory source)
         (extract-tarball (source-archive source)
                          (tmp-path #P"source-http/repos/")))

--- a/src/source/ql.lisp
+++ b/src/source/ql.lisp
@@ -5,6 +5,8 @@
   (:import-from :qlot.util
                 :find-qlfile
                 :with-package-functions)
+  (:import-from :qlot.proxy
+                :get-proxy)
   (:import-from :function-cache
                 :defcached)
   (:import-from :alexandria
@@ -78,7 +80,8 @@
 
 (defcached ql-latest-version ()
   (let ((stream (dex:get "http://beta.quicklisp.org/dist/quicklisp.txt"
-                         :want-stream t)))
+                         :want-stream t
+                         :proxy (get-proxy))))
     (or
      (loop for line = (read-line stream nil nil)
            while line
@@ -89,12 +92,14 @@
 (defun retrieve-quicklisp-releases (version)
   (dex:get (format nil "http://beta.quicklisp.org/dist/quicklisp/~A/releases.txt"
                    version)
-           :want-stream t))
+           :want-stream t
+           :proxy (get-proxy)))
 
 (defun retrieve-quicklisp-systems (version)
   (dex:get (format nil "http://beta.quicklisp.org/dist/quicklisp/~A/systems.txt"
                    version)
-           :want-stream t))
+           :want-stream t
+           :proxy (get-proxy)))
 
 (defun source-ql-releases (source)
   (with-slots (project-name) source


### PR DESCRIPTION
Depend on https://github.com/fukamachi/dexador/pull/26

I think if qlot runs on proxy environment, it makes us more happy.
When set "http_proxy" or "HTTP_PROXY", This PR use it.