### PR TITLE
Preserve pathname components when getting a directory pathname.

### DIFF
--- a/util.lisp
+++ b/util.lisp
@@ -131,7 +131,7 @@ with the same key."
          (setf ,g-qlhome
                (make-pathname :name nil
                               :type nil
-                              :directory (pathname-directory ,g-system-file))))
+                              :defaults ,g-system-file)))
        (call-in-local-quicklisp
         (lambda () ,@body)
         ,g-qlhome


### PR DESCRIPTION
Pathnames contain more components than just the directory, name, and type;
if you create a directory pathname out of a name, type, and directory,
you'll lose the other parts of the original pathname. By using :defaults,
you can un-set specific components and inherit the rest from the original
pathname.

This fixes qlot:quickload on Windows, which stores the drive letter of
paths in the DEVICE component of pathnames.