### PR TITLE
Now qlot exec extends value of CL_SOURCE_REGISTRY env variable if it is exists.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -164,6 +164,31 @@ $ qlot update
 $ qlot bundle
 ```
 
+### exec
+
+`qlot exec` does following:
+
+* configures `CL_SOURCE_REGISTRY` environment variable by adding a current directory;
+* adds Roswell's `bin` directory to the `PATH` environment variable;
+* executes given command with arguments.
+
+Here are few usefull commands:
+
+* `qlot exec ros emacs` - starts Emacs for development. Inferior lisp will use only
+  systems, installed by `qlot install`. If you want to use systems from directories other than
+  current and `./quicklisp/`, then set `CL_SOURCE_REGISTRY` variable before starting `qlot`.
+  This can be useful in case, if you have development versions of some systems, for example,
+  in `~/common-lisp/` directory and want to use them during project development:
+  
+  ```
+  CL_SOURCE_REGISTRY=~/common-lisp// qlot exec ros emacs
+  ```
+  
+  Read more about `CL_SOURCE_REGISTRY` in
+  [asdf's documentation](https://common-lisp.net/project/asdf/asdf/Shell_002dfriendly-syntax-for-configuration.html).
+* `qlot exec ros build some-app.ros` - another command, useful, to build a binary
+  from systems, fixed in `qlfile` and `qlfile.lock`. This way you can be sure that your builds are stable.
+
 ## `qlfile` syntax
 
 "qlfile" is a collection of Quicklisp dist declarations. Each line of that represents a dist.

--- a/qlot.asd
+++ b/qlot.asd
@@ -11,5 +11,6 @@
   :class :package-inferred-system
   :depends-on ("rove"
                "qlot/tests/parser"
-               "qlot/tests/main")
+               "qlot/tests/main"
+               "qlot/tests/util")
   :perform (test-op (op c) (symbol-call :rove :run c)))

--- a/roswell/qlot.ros
+++ b/roswell/qlot.ros
@@ -68,8 +68,13 @@ COMMANDS:
                    (ros:getenv "QUICKLISP_HOME"))))
 
   ;; Overwrite CL_SOURCE_REGISTRY to the current directory
+  (ros:quicklisp)
+  (uiop:symbol-call :ql :quickload :qlot :silent t)
   (setenv "CL_SOURCE_REGISTRY"
-          (uiop:native-namestring (probe-file *default-pathname-defaults*))))
+          (uiop:symbol-call :qlot/util :extend-source-registry
+                            (uiop:getenv "CL_SOURCE_REGISTRY")
+                            (uiop:native-namestring (probe-file *default-pathname-defaults*)))))
+
 
 (defun parse-argv (argv)
   (let ((target nil)
@@ -95,6 +100,7 @@ COMMANDS:
                   (print-error "'~A' does not exist." target))
               :projects projects)
         (list :projects projects))))
+
 
 (defun main (&optional $1 &rest argv)
   (declare (ignorable argv))

--- a/tests/util.lisp
+++ b/tests/util.lisp
@@ -1,0 +1,18 @@
+(defpackage #:qlot/tests/util
+  (:use #:cl
+        #:qlot
+        #:rove)
+  (:import-from #:qlot/util
+                #:extend-source-registry)
+  (:import-from #:uiop
+                #:file-exists-p
+                #:delete-directory-tree
+                #:subdirectories))
+(in-package #:qlot/tests/util)
+
+
+(deftest extend-registry-test
+  (rove:ok (string-equal
+            (extend-source-registry "(:source-registry (:tree (:home \"common-lisp\")) :inherit-configuration)"
+                                    "foo/bar")
+            "(:SOURCE-REGISTRY (:DIRECTORY (\"foo/bar\")) (:TREE (:HOME \"common-lisp\")) :INHERIT-CONFIGURATION)")))


### PR DESCRIPTION
This useful, to add a directory, containing a libraries, available only locally.

For example, I have some libraries at my `~/common-lisp/` directory. But when I make "isolated" environment using Qlot, quicklisp does not see them even if I run qlot like that:

```
CL_SOURCE_REGISTRY=~/common-lisp// qlot exec ros emacs
```

This patch fixes this behavior and if environment variable `CL_SOURCE_REGISTRY` is already defined, then Qlot uses it's content and extends it, making all libraries from `~/common-lisp/` directory (or other) available.