### PR TITLE
Fix handling of asdf::*registered-systems* values in asdf 3.3.

### DIFF
--- a/util.lisp
+++ b/util.lisp
@@ -98,10 +98,11 @@ with the same key."
 
     ;; Set systems already loaded to prevent reloading the same library in the local Quicklisp.
     (maphash (lambda (name system)
-               (let ((system-path (asdf:system-source-directory (cdr system))))
+               (let* ((system-object #+asdf3.3 system #-asdf3.3 (cdr system))
+                      (system-path (asdf:system-source-directory system-object)))
                  (when (or (null system-path)
                            (pathname-in-directory-p system-path qlhome)
-                           (typep (cdr system) 'asdf:require-system))
+                           (typep system-object 'asdf:require-system))
                    (setf (gethash name #+asdf3.3 asdf::*registered-systems*
                                        #-asdf3.3 asdf::*defined-systems*) system))))
              original-defined-systems)


### PR DESCRIPTION
In asdf 3.3 `asdf::*defined-systems*` was replaced with
`asdf::*registered-systems*`, which also changed the structure of the data:
the values in that hashtable are the system objects, and not a cons of the
timestamp and the system object. This adapts the code to handle both cases,
so it should remain compatible with older asdf releases.