### PR TITLE
Added a 'dist' command to use custom Quicklisp distributions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ before_script:
   - ros config
 
 script:
-  - ros -s rove -e '(rove:run :qlot/tests)'
+  - ros -s rove -e '(unless (rove:run :qlot/tests) (uiop:quit 1)'

--- a/dist.lisp
+++ b/dist.lisp
@@ -1,0 +1,43 @@
+(defpackage #:qlot/dist
+  (:use #:cl)
+  (:export
+   ;; #:make-dists-storage
+   ;; #:add-dist
+   ;; #:search-dist
+   #:register-distribution))
+(in-package #:qlot/dist)
+
+
+;; (defclass dist ()
+;;   ((name :initarg :name
+;;          :reader dist-name)
+;;    (url :initarg :url
+;;         :reader dist-url)))
+
+
+;; (defun make-dists-storage ()
+;;   (make-hash-table))
+
+
+;; (defun add-dist (dists name url)
+;;   (check-type dists hash-table)
+;;   (check-type name keyword)
+;;   (check-type url string)
+  
+;;   (setf (gethash name dists)
+;;         url))
+
+
+;; (defun search-dist (dists name)
+;;   (check-type dists hash-table)
+;;   (check-type name keyword)
+;;   (gethash name dists))
+
+
+(defun register-distribution (name url)
+  (defmethod qlot/source:make-source ((source (eql (qlot/util:make-keyword name)))
+                                      &rest args)
+    (apply #'qlot/source:make-source
+           :ql
+           :distribution url
+           args)))

--- a/install.lisp
+++ b/install.lisp
@@ -44,6 +44,15 @@
                 #:directory-pathname-p
                 #:pathname-directory-pathname
                 #:delete-directory-tree)
+
+  ;; We need to import from these packages explicitly
+  ;; because they add make-source methods and these methods
+  ;; should be available during 'qlot install' or 'qlot update'
+  (:import-from #:qlot/source/ql)
+  (:import-from #:qlot/source/git)
+  (:import-from #:qlot/source/github)
+  (:import-from #:qlot/source/http)
+
   #+sbcl
   (:import-from #:sb-posix)
   (:export #:install-quicklisp

--- a/parser.lisp
+++ b/parser.lisp
@@ -62,8 +62,8 @@
                                             arg))
                                       args))
            ;; TODO: add proper condition classes for other implementations
-           #+ccl
-           (ccl:no-applicable-method-exists ()
+           ((or #+sbcl sb-pcl::no-applicable-method-error
+                #+ccl ccl:no-applicable-method-exists) ()
              (error 'qlot-qlfile-error
                     :format-control "Unknown source type: ~A"
                     :format-arguments (list source-type)))))))))

--- a/parser.lisp
+++ b/parser.lisp
@@ -2,7 +2,6 @@
   (:use #:cl)
   (:import-from #:qlot/source
                 #:make-source
-                #:find-source-class
                 #:defrost-source
                 #:source-project-name
                 #:source-version

--- a/source.lisp
+++ b/source.lisp
@@ -20,7 +20,6 @@
            #:freeze-source-slots
            #:defrost-source
            #:source-direct-dependencies
-           #:find-source-class
            #:prepare
            #:update-available-p
            #:project-name
@@ -46,13 +45,6 @@
 
 (defvar *dist-base-url* nil)
 
-(defun find-source-class (class-name)
-  (let* ((package-name (format nil "~A/~:@(~A~)"
-                               :qlot/source class-name))
-         (package (find-package package-name)))
-    (when package
-      (intern (format nil "~A-~:@(~A~)" :source class-name)
-              package))))
 
 (defclass source ()
   ((project-name :initarg :project-name

--- a/source.lisp
+++ b/source.lisp
@@ -3,6 +3,7 @@
   (:import-from #:qlot/tmp
                 #:tmp-path)
   (:import-from #:qlot/util
+                #:make-keyword
                 #:find-qlfile
                 #:with-package-functions
                 #:sbcl-contrib-p
@@ -68,7 +69,8 @@
 (defmethod initialize-instance :after ((source source) &rest initargs)
   (setf (slot-value source 'initargs) initargs))
 
-(defgeneric make-source (source &rest args))
+(defgeneric make-source (source &rest args)
+  (:documentation "Receives a keyword, denoting a source type and returns an instance of such source."))
 
 (defgeneric freeze-source-slots (source)
   (:method ((source source))

--- a/source/git.lisp
+++ b/source/git.lisp
@@ -30,7 +30,7 @@
    (git-cloned-p :initform nil
                  :accessor git-cloned-p)))
 
-(defmethod make-source ((source (eql 'source-git)) &rest initargs)
+(defmethod make-source ((source (eql :git)) &rest initargs)
   (destructuring-bind (project-name remote-url &rest args) initargs
     (apply #'make-instance 'source-git
            :project-name project-name

--- a/source/github.lisp
+++ b/source/github.lisp
@@ -44,7 +44,7 @@
     (setf (source-http-url source)
           (source-github-url source))))
 
-(defmethod make-source ((source (eql 'source-github)) &rest args)
+(defmethod make-source ((source (eql :github)) &rest args)
   (destructuring-bind (project-name repos &key ref branch tag) args
     (make-instance 'source-github
                    :project-name project-name

--- a/source/http.lisp
+++ b/source/http.lisp
@@ -23,7 +23,7 @@
                 :initform nil
                 :accessor source-http-archive-md5)))
 
-(defmethod make-source ((source (eql 'source-http)) &rest args)
+(defmethod make-source ((source (eql :http)) &rest args)
   (destructuring-bind (project-name url &optional archive-md5) args
     (make-instance 'source-http
                    :project-name project-name

--- a/util.lisp
+++ b/util.lisp
@@ -13,7 +13,8 @@
            #:with-in-directory
            #:project-systems
            #:sbcl-contrib-p
-           #:with-retrying))
+           #:with-retrying
+           #:make-keyword))
 (in-package #:qlot/util)
 
 (defvar *system-quicklisp-home*
@@ -204,3 +205,8 @@ with the same key."
                               #-quicklisp (asdf:load-system (asdf::missing-requires ,e))
                               (go retry)))))
            ,@body)))))
+
+(defun make-keyword (text)
+  "This function differ from alexandria:make-keyword
+   because it upcases text before making it a keyword."
+  (intern (string-upcase text) :keyword))


### PR DESCRIPTION
This pull request adds ability to define and use custom Quicklisp distributions, as suggested in https://github.com/fukamachi/qlot/issues/58:

```
dist ultralisp http://dist.ultralisp.org/

ql :all :latest
ultralisp weblocks 20180827-194049

github slynk joaotavora/sly
…
```

I think code should be refactored a little bit before this pull can be merged.