### PR TITLE
Mitigate uninitialized dist system indexes for multi-system sources

### DIFF
--- a/install.lisp
+++ b/install.lisp
@@ -220,13 +220,13 @@
 
     (with-quicklisp-home qlhome
       (with-qlot-server all-sources
-        (flet ((install-all-releases (source)
+        (flet ((install-all-releases (source &optional dist)
                  (unless (equal (symbol-name (type-of source))
                                 (string :source-ql-all))
                    (let ((*standard-output* (make-broadcast-stream))
                          (*trace-output* (make-broadcast-stream)))
                      (with-package-functions :ql-dist (dist provided-releases ensure-installed base-directory)
-                       (let ((releases (provided-releases (dist (source-dist-name source)))))
+                       (let ((releases (provided-releases (or dist (dist (source-dist-name source))))))
                          (dolist (release releases)
                            (ensure-installed release)
 
@@ -259,8 +259,8 @@ qlot exec /bin/sh \"$CURRENT/../~A\" \"$@\"
                 for preference from (get-universal-time)
                 do (cond
                      ((not (already-installed-p source))
-                      (install-source source)
-                      (install-all-releases source))
+                      (let ((dist (install-source source)))
+                        (install-all-releases source dist)))
                      ((source-update-available-p source)
                       (prepare source)
                       (if (string= (source-dist-name source) "quicklisp")


### PR DESCRIPTION
# Issue Mitigation
**Important note**: This is only proof-of-concept code to get the idea across. It is not a complete solution, and needs further discussion and implementation work. I wanted to get feedback early; I'll update the branch as time permits.

This code address attempts to mitigate what I believe to be an issue in quicklisp (https://github.com/quicklisp/quicklisp-client/issues/173), because some people may run old quicklisp clients, and extra defense never hurt anybody (there is also a minor performance boost to be had).

When installing a system, fetching a dist object by using
`(ql-dist:dist "name")` results in a dist object whose system-index is not
properly initialized. This will result in the `provided-systems` for one of
the dist's releases including a bunch of entries that are `nil`, because
`find-system-in-dist` was unable to locate the system in the index. That
causes release installation to fail, because `(ql-dist:install nil)` is not
a valid call.

While I believe this to be a bug in quicklisp, qlot can mitigate the issue
by using the dist object returned by `ql-dist:install-dist` (which _does_
have a properly initialized system index) when installing releases. The
code in this branch does this for the simple case where a dist is not
already installed. This also means not having to hit the disk again to
reconstruct a dist object that we just finished loading up.

# Test case
Wookie is a system that exhibits this issue, which I believe only applies to sources that contain more than one system. The following can be used as a test case:
````
;;; qlfile
github wookie orthecreedence/wookie


;;; qlfile.lock
("quicklisp" .
 (:class qlot.source.ql:source-ql-all
  :initargs (:distribution "http://beta.quicklisp.org/dist/quicklisp.txt" :%version :latest)
  :version "2018-08-31"))
("wookie" .
 (:class qlot.source.github:source-github
  :initargs (:project-name "wookie" :repos "orthecreedence/wookie" :ref nil :branch nil :tag nil)
  :version "github-c047d0063c6404b2ef3cc411933390df686dfa91"
  :repos "orthecreedence/wookie"
  :url "https://github.com/orthecreedence/wookie/archive/c047d0063c6404b2ef3cc411933390df686dfa91.tar.gz"
  :ref "c047d0063c6404b2ef3cc411933390df686dfa91"))


;;; wookie-patch.lisp
;; Wookie has systems that are not loadable (blacklisted in quicklisp, but we have to
;; patch them out when loaded via qlot).
(defpackage #:wookie
  (:use #:cl)
  (:export #:defplugin))

(defmacro wookie:defplugin (&rest args)
  (declare (ignore args))
  '(asdf:defsystem #:plugin :components ()))

;; Need qlot loaded, duh.
(ql:quickload :qlot)
(push *default-pathname-defaults* asdf:*central-registry*)


;;; test.asd
(defsystem #:test :components ())
````
With those files in place, removing the `quicklisp/` directory and running `sbcl --load wookie-patch.lisp --eval "(qlot:install :test)"` will produce an error about `ql-dist:install` not being specialized for the argument `nil`. Applying the code in this branch will make this test case succeed.