### PR TITLE
initialize qlot/util::*already-seen* as nil

### DIFF
--- a/util.lisp
+++ b/util.lisp
@@ -155,7 +155,7 @@ with the same key."
     (and (<= 3 (length name))
          (string-equal name "sb-" :end1 3))))
 
-(defvar *already-seen*)
+(defvar *already-seen* nil)
 
 (defun all-required-systems (systems)
   (let ((systems (if (listp systems) systems (list systems)))


### PR DESCRIPTION
`The variable QLOT/UTIL::*ALREADY-SEEN* is unbound.` may be occur in `all-required-systems` because `*already-seen*` is unbound.

I initialized `*already-seen*` as `nil`.