### PR TITLE
Resolve primary system name when installing dependencies

### DIFF
--- a/install.lisp
+++ b/install.lisp
@@ -370,7 +370,8 @@ qlot exec /bin/sh \"$CURRENT/../~A\" \"$@\"
                                      :test 'equal))))
                   (format t "~&Ensuring ~D ~:*dependenc~[ies~;y~:;ies~] installed.~%" (length dependencies))
                   (mapc #'ensure-installed
-                        (mapcar #'find-system dependencies))
+                        (mapcar #'find-system
+                                (mapcar #'asdf:primary-system-name dependencies)))
 
                   (when (find-if (lambda (s) (typep s 'asdf:package-inferred-system))
                                  systems)
@@ -391,7 +392,8 @@ qlot exec /bin/sh \"$CURRENT/../~A\" \"$@\"
                       (format t "~&Ensuring additional ~D ~:*dependenc~[ies~;y~:;ies~] installed.~%"
                               (length pis-dependencies))
                       (mapc #'ensure-installed
-                            (mapcar #'find-system pis-dependencies)))))))))))
+                            (mapcar #'find-system
+                                    (mapcar #'asdf:primary-system-name pis-dependencies))))))))))))
 
     #+windows
     (uiop:run-program (list "attrib"

--- a/install.lisp
+++ b/install.lisp
@@ -339,7 +339,10 @@ qlot exec /bin/sh \"$CURRENT/../~A\" \"$@\"
                                 (setf (gethash system-name *already-seen*) t)
                                 (mapcan #'system-dependencies
                                         (mapcar #'string-downcase
-                                                (asdf::component-sideway-dependencies system)))))))))
+                                                (asdf::component-sideway-dependencies system))))))))
+                       (find-system-with-fallback (system-name)
+                         (or (find-system system-name)
+                             (find-system (asdf:primary-system-name system-name)))))
                 (let ((*dependencies* (make-hash-table :test 'equal)))
                   (let ((*macroexpand-hook* (lambda (&rest args)
                                               (declare (ignore args)))))
@@ -370,8 +373,7 @@ qlot exec /bin/sh \"$CURRENT/../~A\" \"$@\"
                                      :test 'equal))))
                   (format t "~&Ensuring ~D ~:*dependenc~[ies~;y~:;ies~] installed.~%" (length dependencies))
                   (mapc #'ensure-installed
-                        (mapcar #'find-system
-                                (mapcar #'asdf:primary-system-name dependencies)))
+                        (mapcar #'find-system-with-fallback dependencies))
 
                   (when (find-if (lambda (s) (typep s 'asdf:package-inferred-system))
                                  systems)
@@ -392,8 +394,7 @@ qlot exec /bin/sh \"$CURRENT/../~A\" \"$@\"
                       (format t "~&Ensuring additional ~D ~:*dependenc~[ies~;y~:;ies~] installed.~%"
                               (length pis-dependencies))
                       (mapc #'ensure-installed
-                            (mapcar #'find-system
-                                    (mapcar #'asdf:primary-system-name pis-dependencies))))))))))))
+                            (mapcar #'find-system-with-fallback pis-dependencies)))))))))))
 
     #+windows
     (uiop:run-program (list "attrib"

--- a/main.lisp
+++ b/main.lisp
@@ -80,7 +80,7 @@ If PATH isn't specified, this installs it to './quicklisp/'."
             (setf required-systems
                   (delete-if (lambda (system)
                                (or (member system systems :key #'pathname-name :test #'string-equal)
-                                   (not (find-system system))))
+                                   (not (find-system (asdf:primary-system-name system)))))
                              (mapcan #'system-dependencies
                                      (mapcar #'pathname-name systems)))))))
       (delete-duplicates


### PR DESCRIPTION
This PR attempts to fix https://github.com/fukamachi/qlot/issues/74 by consistently using primary-system-name with ql-dist:find-system