### PR TITLE
Change the directory name of project-local Quicklisp to '.qlot/'.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -69,10 +69,10 @@ Usage: qlot COMMAND [ARGS..]
 
 COMMANDS:
     install
-        Installs libraries to './quicklisp'.
+        Installs libraries to './.qlot'.
 
     update
-        Makes './quicklisp' up-to-date and update 'qlfile.lock'.
+        Makes './.qlot' up-to-date and update 'qlfile.lock'.
         Possible to update specific projects with --project option.
         ex) qlot update --project mito
 
@@ -102,21 +102,21 @@ You can install libraries into the project directory via:
 $ qlot install
 ```
 
-It creates `quicklisp/` directory in the project directory and a file `qlfile.lock`.
+It creates `.qlot/` directory in the project directory and a file `qlfile.lock`.
 
 `qlfile.lock` is similar to `qlfile` except the library versions are qualified. This will ensure that other developers or your deployment environment use exactly the same versions of libraries you just installed.
 
-Make sure you add `qlfile` and `qlfile.lock` to your version controlled repository and make the `quicklisp/` directory ignored.
+Make sure you add `qlfile` and `qlfile.lock` to your version controlled repository and make the `.qlot/` directory ignored.
 
 ```
-$ echo quicklisp/ >> .gitignore
+$ echo .qlot/ >> .gitignore
 $ git add qlfile qlfile.lock
 $ git commit -m 'Start using Qlot.'
 ```
 
-### Updating the project-local quicklisp
+### Updating the project-local Quicklisp
 
-You can update the content of `quicklisp/` directory via:
+You can update the content of `.qlot/` directory via:
 
 ```
 $ qlot update
@@ -150,7 +150,7 @@ $ qlot install /path/to/myapp/qlfile
 
 ### update
 
-`qlot update` will update the project-local `quicklisp/` directory using `qlfile`.
+`qlot update` will update the project-local `.qlot/` directory using `qlfile`.
 
 ```
 $ qlot update
@@ -176,7 +176,7 @@ Here are few usefull commands:
 
 * `qlot exec ros emacs` - starts Emacs for development. Inferior lisp will use only
   systems, installed by `qlot install`. If you want to use systems from directories other than
-  current and `./quicklisp/`, then set `CL_SOURCE_REGISTRY` variable before starting `qlot`.
+  current and `./.qlot/`, then set `CL_SOURCE_REGISTRY` variable before starting `qlot`.
   This can be useful in case, if you have development versions of some systems, for example,
   in `~/common-lisp/` directory and want to use them during project development:
   
@@ -308,7 +308,7 @@ Here's quick steps to start project-local REPL with SLIME:
 
 ## Working with local git repositories
 
-`PROJECT_ROOT/quicklisp/local-projects` can be used for local git repositories. Symbolic links are also be accessible in Qlot environment.
+`PROJECT_ROOT/.qlot/local-projects` can be used for local git repositories. Symbolic links are also be accessible in Qlot environment.
 
 ## Author
 

--- a/install.lisp
+++ b/install.lisp
@@ -74,7 +74,7 @@
    #+cmu (car ext:*command-line-strings*)
    #+ecl (car (si:command-args))))
 
-(defun install-quicklisp (&optional (path (merge-pathnames #P"quicklisp/" *default-pathname-defaults*)))
+(defun install-quicklisp (&optional (path (merge-pathnames #P".qlot/" *default-pathname-defaults*)))
   (format t "~&Installing Quicklisp to ~A ...~%" path)
   (let ((*standard-output* (make-broadcast-stream))
         (quicklisp-file (merge-pathnames (format nil "quicklisp-~A.lisp"
@@ -145,7 +145,7 @@
       qlhome
       (merge-pathnames qlhome base)))
 
-(defun install-qlfile (file &key (quicklisp-home #P"quicklisp/"))
+(defun install-qlfile (file &key (quicklisp-home #P".qlot/"))
   (unless (uiop:file-exists-p file)
     (error "File does not exist: ~A" file))
 
@@ -161,7 +161,7 @@
 
     (format t "~&Successfully installed.~%")))
 
-(defun update-qlfile (file &key (quicklisp-home #P"quicklisp/") projects)
+(defun update-qlfile (file &key (quicklisp-home #P".qlot/") projects)
   (unless (uiop:file-exists-p file)
     (error "File does not exist: ~A" file))
 
@@ -224,7 +224,7 @@
           (loop for dir in (uiop:subdirectories dir)
                 when (not (member (car (last (pathname-directory dir)))
                                   (append asdf/source-registry:*default-source-registry-exclusions*
-                                          (list "quicklisp"))
+                                          (list "quicklisp" ".qlot"))
                                   :test 'equal))
                 append (project-lisp-files dir))))
 
@@ -414,7 +414,7 @@ qlot exec /bin/sh \"$CURRENT/../~A\" \"$@\"
     (let ((system-dir (asdf:component-pathname object)))
       (unless quicklisp-home
         (setf args
-              (list* :quicklisp-home (asdf:system-relative-pathname object #P"quicklisp/")
+              (list* :quicklisp-home (asdf:system-relative-pathname object #P".qlot/")
                      args)))
       (apply #'install-qlfile
              (find-qlfile system-dir)
@@ -424,7 +424,7 @@ qlot exec /bin/sh \"$CURRENT/../~A\" \"$@\"
            (dir (uiop:pathname-directory-pathname object)))
       (unless quicklisp-home
         (setf args
-              (list* :quicklisp-home (merge-pathnames #P"quicklisp/" dir)
+              (list* :quicklisp-home (merge-pathnames #P".qlot/" dir)
                      args)))
       (if (uiop:directory-pathname-p object)
           (apply #'install-qlfile (find-qlfile object) args)
@@ -439,7 +439,7 @@ qlot exec /bin/sh \"$CURRENT/../~A\" \"$@\"
     (let ((system-dir (asdf:component-pathname object)))
       (unless quicklisp-home
         (setf args
-              (list* :quicklisp-home (asdf:system-relative-pathname object #P"quicklisp/")
+              (list* :quicklisp-home (asdf:system-relative-pathname object #P".qlot/")
                      args)))
       (apply #'update-qlfile
              (find-qlfile system-dir :errorp nil)
@@ -449,7 +449,7 @@ qlot exec /bin/sh \"$CURRENT/../~A\" \"$@\"
            (dir (uiop:pathname-directory-pathname object)))
       (unless quicklisp-home
         (setf args
-              (list* :quicklisp-home (merge-pathnames #P"quicklisp/" dir)
+              (list* :quicklisp-home (merge-pathnames #P".qlot/" dir)
                      args)))
       (if (uiop:directory-pathname-p object)
           (apply #'update-qlfile (find-qlfile object) args)

--- a/main.lisp
+++ b/main.lisp
@@ -30,7 +30,7 @@ qlfile.lock will be used with precedence if it exists."
         (apply #'install-project args))))
 
 (defun update (&rest args)
-  "Update the project-local 'quicklisp/' directory using qlfile."
+  "Update the project-local '.qlot/' directory using qlfile."
   (ensure-qlot-install)
   (with-package-functions :qlot/install (update-project)
     (if (evenp (length args))
@@ -39,7 +39,7 @@ qlfile.lock will be used with precedence if it exists."
 
 (defun install-quicklisp (&optional (path nil path-specified-p))
   "Install Quicklisp in the given PATH.
-If PATH isn't specified, this installs it to './quicklisp/'."
+If PATH isn't specified, this installs it to './.qlot/'."
   (ensure-qlot-install)
   (with-package-functions :qlot/install (install-quicklisp)
     (apply #'install-quicklisp (if path-specified-p
@@ -47,7 +47,7 @@ If PATH isn't specified, this installs it to './quicklisp/'."
                                    nil))))
 
 (defun quickload (systems &rest args &key verbose prompt explain &allow-other-keys)
-  "Load SYSTEMS in the each project-local `quicklisp/`."
+  "Load SYSTEMS in the each project-local `.qlot/`."
   (declare (ignore verbose prompt explain))
   (unless (consp systems)
     (setf systems (list systems)))

--- a/parser.lisp
+++ b/parser.lisp
@@ -40,7 +40,7 @@
     (setf line (canonical-line line))
     (when (string= line "")
       (return-from parse-qlfile-line))
-    
+
     (destructuring-bind (source-type &rest args)
         (split-sequence #\Space line :remove-empty-subseqs t)
       (cond

--- a/roswell/qlot.ros
+++ b/roswell/qlot.ros
@@ -30,10 +30,10 @@ exec ros +Q -L sbcl-bin -- $0 "$@"
 
 COMMANDS:
     install
-        Installs libraries to './quicklisp'.
+        Installs libraries to './.qlot'.
 
     update
-        Makes './quicklisp' up-to-date and update 'qlfile.lock'.
+        Makes './.qlot' up-to-date and update 'qlfile.lock'.
         Possible to update specific projects with --project option.
         ex) qlot update --project mito
 
@@ -57,9 +57,9 @@ OPTIONS:
           (asdf:component-version (asdf:find-system :qlot))))
 
 (defun use-local-quicklisp ()
-  ;; Set QUICKLISP_HOME ./quicklisp/
+  ;; Set QUICKLISP_HOME ./.qlot/
   (unless (ros:getenv "QUICKLISP_HOME")
-    (setenv "QUICKLISP_HOME" "quicklisp/"))
+    (setenv "QUICKLISP_HOME" ".qlot/"))
   (let ((path (or (probe-file (ros:getenv "QUICKLISP_HOME"))
                   (merge-pathnames (ros:getenv "QUICKLISP_HOME")
                                    (make-pathname :defaults *load-pathname* :name nil :type nil)))))

--- a/roswell/qlot.ros
+++ b/roswell/qlot.ros
@@ -59,6 +59,11 @@ OPTIONS:
 (defun use-local-quicklisp ()
   ;; Set QUICKLISP_HOME ./.qlot/
   (unless (ros:getenv "QUICKLISP_HOME")
+    (when (and (not (uiop:directory-exists-p #P".qlot/"))
+               (uiop:directory-exists-p #P"quicklisp/")
+               (uiop:file-exists-p #P"quicklisp/setup.lisp"))
+      (uiop:symbol-call :ql :quickload :qlot/util :silent t)
+      (uiop:symbol-call :qlot/util :rename-quicklisp-to-dot-qlot))
     (setenv "QUICKLISP_HOME" ".qlot/"))
   (let ((path (or (probe-file (ros:getenv "QUICKLISP_HOME"))
                   (merge-pathnames (ros:getenv "QUICKLISP_HOME")

--- a/roswell/qlot.ros
+++ b/roswell/qlot.ros
@@ -63,7 +63,7 @@ OPTIONS:
                (uiop:directory-exists-p #P"quicklisp/")
                (uiop:file-exists-p #P"quicklisp/setup.lisp"))
       (uiop:symbol-call :ql :quickload :qlot/util :silent t)
-      (uiop:symbol-call :qlot/util :rename-quicklisp-to-dot-qlot))
+      (uiop:symbol-call :qlot/util :rename-quicklisp-to-dot-qlot nil t))
     (setenv "QUICKLISP_HOME" ".qlot/"))
   (let ((path (or (probe-file (ros:getenv "QUICKLISP_HOME"))
                   (merge-pathnames (ros:getenv "QUICKLISP_HOME")

--- a/tests/main.lisp
+++ b/tests/main.lisp
@@ -30,22 +30,22 @@
     (delete-if-exists "qlfile3.lock")))
 
 (deftest uninstall-test
-  (let ((res (install-quicklisp (merge-pathnames #P"quicklisp/" *tmp-directory*))))
+  (let ((res (install-quicklisp (merge-pathnames #P".qlot/" *tmp-directory*))))
     (ok (not (null res)) "can install Quicklisp"))
 
-  (dolist (dir (uiop:subdirectories (merge-pathnames #P"quicklisp/dists/" *tmp-directory*)))
+  (dolist (dir (uiop:subdirectories (merge-pathnames #P".qlot/dists/" *tmp-directory*)))
     (uiop:delete-directory-tree dir :validate t :if-does-not-exist :ignore))
 
-  (ok (null (uiop:subdirectories (merge-pathnames #P"quicklisp/dists/" *tmp-directory*)))
+  (ok (null (uiop:subdirectories (merge-pathnames #P".qlot/dists/" *tmp-directory*)))
       "can uninstall all dists"))
 
 (deftest install-test
   (install (asdf:system-relative-pathname :qlot #P"tests/data/qlfile")
-           :quicklisp-home (merge-pathnames #P"quicklisp/" *tmp-directory*))
+           :quicklisp-home (merge-pathnames #P".qlot/" *tmp-directory*))
 
   (ok (equal (mapcar (lambda (path)
                        (car (last (pathname-directory path))))
-                     (uiop:subdirectories (merge-pathnames #P"quicklisp/dists/" *tmp-directory*)))
+                     (uiop:subdirectories (merge-pathnames #P".qlot/dists/" *tmp-directory*)))
              '("cl-dbi"
                "clack"
                "datafly"
@@ -56,11 +56,11 @@
 
 (deftest update-test
   (update (asdf:system-relative-pathname :qlot #P"tests/data/qlfile2")
-          :quicklisp-home (merge-pathnames #P"quicklisp/" *tmp-directory*))
+          :quicklisp-home (merge-pathnames #P".qlot/" *tmp-directory*))
 
   (ok (equal (mapcar (lambda (path)
                        (car (last (pathname-directory path))))
-                     (uiop:subdirectories (merge-pathnames #P"quicklisp/dists/" *tmp-directory*)))
+                     (uiop:subdirectories (merge-pathnames #P".qlot/dists/" *tmp-directory*)))
              '("datafly"
                "log4cl"
                "quicklisp"
@@ -68,15 +68,15 @@
       "can update dists from qlfile")
 
   (update (asdf:system-relative-pathname :qlot #P"tests/data/qlfile3")
-          :quicklisp-home (merge-pathnames #P"quicklisp/" *tmp-directory*))
+          :quicklisp-home (merge-pathnames #P".qlot/" *tmp-directory*))
 
   (ok (equal (mapcar (lambda (path)
                        (car (last (pathname-directory path))))
-                     (uiop:subdirectories (merge-pathnames #P"quicklisp/dists/" *tmp-directory*)))
+                     (uiop:subdirectories (merge-pathnames #P".qlot/dists/" *tmp-directory*)))
              '("quicklisp"))
       "can install dists from qlfile")
 
   (ok
    (search "version: 2014-12-17"
-           (alexandria:read-file-into-string (merge-pathnames #P"quicklisp/dists/quicklisp/distinfo.txt" *tmp-directory*)))
+           (alexandria:read-file-into-string (merge-pathnames #P".qlot/dists/quicklisp/distinfo.txt" *tmp-directory*)))
    "can install old Quicklisp dist"))

--- a/util.lisp
+++ b/util.lisp
@@ -76,10 +76,16 @@ with the same key."
            (setf (gethash value to-table) key)))
     (maphash #'add-to-original from-table)))
 
-(defun rename-quicklisp-to-dot-qlot (&optional (pwd *default-pathname-defaults*))
+(defun rename-quicklisp-to-dot-qlot (&optional (pwd *default-pathname-defaults*) enable-color)
+  (fresh-line *error-output*)
+  (when enable-color
+    (format *error-output* "~C[33m" #\Esc))
   (format *error-output*
-          "~&Project local Quicklisp directory has changed from 'quicklisp/' to '.qlot/' since v0.9.13.
-See https://github.com/fukamachi/qlot/pull/78 for the details.~%")
+          "Project local Quicklisp directory has changed from 'quicklisp/' to '.qlot/' since v0.9.13.
+See https://github.com/fukamachi/qlot/pull/78 for the details.")
+  (when enable-color
+    (format *error-output* "~C[0m" #\Esc))
+  (fresh-line *error-output*)
   (when (y-or-n-p "Would you like Qlot to migrate?")
     (let ((*default-pathname-defaults* pwd))
       (rename-file #P"quicklisp/" (merge-pathnames #P".qlot/"))

--- a/util.lisp
+++ b/util.lisp
@@ -82,9 +82,9 @@ with the same key."
     (error "Directory ~S does not exist." qlhome))
 
   (unless (probe-file (merge-pathnames #P"setup.lisp" qlhome))
-    (if (probe-file (merge-pathnames #P"quicklisp/setup.lisp" qlhome))
+    (if (probe-file (merge-pathnames #P".qlot/setup.lisp" qlhome))
         ;; The given `qlhome' is the project root.
-        (setf qlhome (merge-pathnames #P"quicklisp/" qlhome))
+        (setf qlhome (merge-pathnames #P".qlot/" qlhome))
         (error "~S is not a quicklisp directory." qlhome)))
 
   (let* (#+quicklisp
@@ -114,9 +114,9 @@ with the same key."
              original-defined-systems)
 
     #-quicklisp
-    (load (merge-pathnames #P"quicklisp/setup.lisp" qlhome))
+    (load (merge-pathnames #P".qlot/setup.lisp" qlhome))
     #+quicklisp
-    (push (merge-pathnames #P"quicklisp/" qlhome) asdf:*central-registry*)
+    (push (merge-pathnames #P".qlot/" qlhome) asdf:*central-registry*)
 
     (asdf:initialize-source-registry)
 
@@ -187,7 +187,7 @@ with the same key."
          (uiop:chdir ,cwd)))))
 
 (defun project-systems (project-dir)
-  (let ((qlhome (merge-pathnames #P"quicklisp/" project-dir))
+  (let ((qlhome (merge-pathnames #P".qlot/" project-dir))
         systems)
     (asdf::collect-sub*directories-asd-files
      project-dir
@@ -196,7 +196,7 @@ with the same key."
                             ;; KLUDGE: Ignore skeleton.asd of CL-Project
                             (search "skeleton" (pathname-name asd)))
                   (push asd systems)))
-     :exclude (append (list "bundle-libs" "quicklisp")
+     :exclude (append (list "bundle-libs" "quicklisp" ".qlot")
                       asdf::*default-source-registry-exclusions*))
     systems))
 


### PR DESCRIPTION
As Quicklisp searches the local-projects directory recursively, it also
searches inside project-local Quicklisp dists if there's a project which
uses Qlot.

I personally heard that @snmsts is willing to add a system searcher which ignores dot-started directories.
With this patch, the issue would be resolved.