### PR TITLE
Reduce dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ env:
     - PATH=~/.roswell/bin:$PATH
     - ROSWELL_INSTALL_DIR=$HOME/.roswell
   matrix:
-    - LISP=sbcl-bin
-    - LISP=ccl-bin
+    - LISP=sbcl-bin/1.5.5
+    #- LISP=ccl-bin
 
 install:
   # Roswell

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ env:
 install:
   # Roswell
   - curl -L https://raw.githubusercontent.com/roswell/roswell/release/scripts/install-for-ci.sh | sh
-  - ros install Shinmera/dissect
   - ros install fukamachi/rove
 
 before_script:

--- a/archive.lisp
+++ b/archive.lisp
@@ -1,57 +1,16 @@
 (defpackage #:qlot/archive
   (:use #:cl)
+  (:import-from #:qlot/util
+                #:with-package-functions)
   (:import-from #:uiop
-                #:pathname-parent-directory-pathname
-                #:directory-files
-                #:subdirectories)
-  (:import-from #:archive
-                #:create-tar-file
-                #:open-archive
-                #:read-entry-from-archive
-                #:extract-files-from-archive)
-  (:import-from #:salza2
-                #:gzip-file)
-  (:import-from #:gzip-stream
-                #:with-open-gzip-file)
-  (:export #:create-tarball
-           #:extract-tarball))
+                #:with-temporary-file)
+  (:export #:extract-tarball))
 (in-package #:qlot/archive)
-
-(defun create-tarball (directory destination)
-  (let ((ignore-len (length (pathname-directory (truename (uiop:pathname-parent-directory-pathname directory)))))
-        (*default-pathname-defaults* (truename (uiop:pathname-parent-directory-pathname directory)))
-        (tar-file (make-pathname
-                   :directory (pathname-directory destination)
-                   :name (pathname-name destination)))
-        (tar-gz-file destination))
-
-    (flet ((to-relative (path)
-             (make-pathname
-              :defaults path
-              :device nil
-              :directory (cons :relative
-                               (nthcdr ignore-len (pathname-directory path)))))
-           (git-dir-p (path)
-             (find ".git"
-                   (nthcdr ignore-len (pathname-directory path))
-                   :test #'string=)))
-      (archive::create-tar-file
-       tar-file
-       (mapcar #'to-relative
-               (remove-if #'git-dir-p
-                          (nconc (uiop:subdirectories directory)
-                                 (uiop:directory-files directory))))))
-
-    (salza2:gzip-file tar-file tar-gz-file)
-    (delete-file tar-file)
-    tar-gz-file))
 
 (defun extract-tarball (tarball &optional (destination *default-pathname-defaults*))
   (let ((*default-pathname-defaults* destination))
-    (with-open-gzip-file (gzip tarball)
-      (let ((archive (archive:open-archive 'archive:tar-archive gzip)))
-        (prog1
-            (merge-pathnames
-             (archive:name (archive:read-entry-from-archive archive))
-             *default-pathname-defaults*)
-          (archive::extract-files-from-archive archive))))))
+    (with-package-functions :ql-minitar (unpack-tarball contents)
+      (with-package-functions :ql-gunzipper (gunzip)
+        (uiop:with-temporary-file (:pathname tarfile :type "tar")
+          (unpack-tarball (gunzip tarball tarfile))
+          (first (contents tarfile)))))))

--- a/archive.lisp
+++ b/archive.lisp
@@ -13,4 +13,4 @@
       (with-package-functions :ql-gunzipper (gunzip)
         (uiop:with-temporary-file (:pathname tarfile :type "tar")
           (unpack-tarball (gunzip tarball tarfile))
-          (first (contents tarfile)))))))
+          (merge-pathnames (first (contents tarfile)) destination))))))

--- a/source/git.lisp
+++ b/source/git.lisp
@@ -6,10 +6,10 @@
                 #:safety-shell-command
                 #:shell-command-error)
   (:import-from #:qlot/util
-                #:with-in-directory)
+                #:with-in-directory
+                #:split-with)
   (:import-from #:uiop
                 #:delete-directory-tree)
-  (:import-from #:cl-ppcre)
   (:export #:source-git
            #:retry-git-clone))
 (in-package #:qlot/source/git)
@@ -100,11 +100,13 @@
   (flet ((show-ref (pattern)
            (handler-case
                (let ((*standard-output* (make-broadcast-stream)))
-                 (ppcre:scan-to-strings "^\\S+"
-                                        (safety-shell-command "git"
-                                                              (list "ls-remote"
-                                                                    (source-git-remote-url source)
-                                                                    pattern))))
+                 (first
+                   (split-with #\Tab
+                               (safety-shell-command "git"
+                                                     (list "ls-remote"
+                                                           (source-git-remote-url source)
+                                                           pattern))
+                               :limit 2)))
              (shell-command-error ()
                (error "No git references named '~A'." pattern)))))
     (or (source-git-ref source)

--- a/source/http.lisp
+++ b/source/http.lisp
@@ -46,7 +46,6 @@
          (format nil "~A.tar.gz" (source-project-name source))))
   (dex:fetch (source-http-url source)
              (source-archive source)
-             :if-exists :supersede
              :proxy (get-proxy))
   (setf (source-directory source)
         (extract-tarball (source-archive source)

--- a/util.lisp
+++ b/util.lisp
@@ -15,6 +15,8 @@
            #:sbcl-contrib-p
            #:with-retrying
            #:make-keyword
+           #:starts-with
+           #:split-with
            #:extend-source-registry))
 (in-package #:qlot/util)
 
@@ -221,6 +223,33 @@ with the same key."
    because it upcases text before making it a keyword."
   (intern (string-upcase text) :keyword))
 
+(defun starts-with (prefix value)
+  (and (<= (length prefix) (length value))
+       (string= prefix value :end2 (length prefix))))
+
+(defun split-with (delimiter value &key limit)
+  (check-type delimiter character)
+  (check-type value string)
+  (check-type limit (or null (integer 1)))
+  (let ((results '())
+        (pos 0)
+        (count 0))
+    (block nil
+      (flet ((keep (i)
+               (unless (= pos i)
+                 (push (subseq value pos i) results)
+                 (incf count))))
+        (do ((i 0 (1+ i)))
+            ((= i (length value))
+             (keep i))
+          (when (and limit
+                     (= (1+ count) limit))
+            (push (subseq value i (length value)) results)
+            (return))
+          (when (char= (aref value i) delimiter)
+            (keep i)
+            (setf pos (1+ i))))))
+    (nreverse results)))
 
 (defun extend-source-registry (current-value dir-to-add)
   "According to ASDF documentation:


### PR DESCRIPTION
This PR removes the following dependencies.

* alexandria
* cl-ppcre
* split-sequence
* archive
* salza2
* gzip-stream

Still ironclad is required for calculating a digest of files, and dexador & yason are required by http/github sources.