### PR TITLE
Fix the bug that 'ql' source ignores the version of the project lock.

### DIFF
--- a/source/ql.lisp
+++ b/source/ql.lisp
@@ -65,6 +65,16 @@
     (setf (slot-value instance 'project-name)
           (retrieve-quicklisp-metadata-item instance :name))))
 
+(defmethod defrost-source :after ((source source-ql))
+  (when (slot-boundp source 'version)
+    (setf (slot-value source 'distribution)
+          (let ((*standard-output* (make-broadcast-stream))
+                (*error-output* (make-broadcast-stream))
+                (*trace-output* (make-broadcast-stream)))
+            (get-versioned-distribution-url source (source-ql-version source))))
+    ;; KLUDGE: Delete the wrong cached distinfo because of the above function call.
+    (slot-makunbound source '%distinfo)))
+
 (defmethod defrost-source :after ((source source-ql-all))
   (when (slot-boundp source 'version)
     (setf (slot-value source 'distribution)


### PR DESCRIPTION
'ql' source cannot lock the version even when there's a qlfile.lock.

## How to reproduce

```
#qlfile
ql fast-http :latest
```
```
#qlfile.lock
("quicklisp" .
 (:class qlot.source.ql:source-ql-all
  :initargs (:project-name "quicklisp" :%version :latest)
  :version "2018-02-28"))
("fast-http" .
 (:class qlot.source.ql:source-ql
  :initargs (:project-name "fast-http" :distribution "http://beta.quicklisp.org/dist/quicklisp.txt" :%version :latest)
  :version "ql-2019-03-07"))
```

```
qlot install
ls .qlot/dists/fast-http/softwares
```