### PR TITLE
Fix a MISSING-COMPONENT error when executing 'qlot exec' recursively.

### DIFF
--- a/roswell/qlot.ros
+++ b/roswell/qlot.ros
@@ -76,8 +76,11 @@ OPTIONS:
   ;; Overwrite CL_SOURCE_REGISTRY to the current directory
   (setenv "CL_SOURCE_REGISTRY"
           (qlot/cli:extend-source-registry
-            (uiop:getenv "CL_SOURCE_REGISTRY")
-            (uiop:native-namestring (truename *default-pathname-defaults*)))))
+            ;; Allow to find Qlot even in the subcommand with recursive 'qlot exec'.
+            (uiop:native-namestring (asdf:system-source-directory :qlot))
+            (qlot/cli:extend-source-registry
+              (uiop:getenv "CL_SOURCE_REGISTRY")
+              (uiop:native-namestring (truename *default-pathname-defaults*))))))
 
 (defmacro case-equal (keyform &body cases)
   (let ((g-keyform (gensym "KEYFORM")))


### PR DESCRIPTION
Here's the first few lines of it:

```
$ qlot exec qlot exec ros run
Unhandled ASDF/FIND-COMPONENT:MISSING-COMPONENT in thread #<SB-THREAD:THREAD "main thread" RUNNING
                                                             {10005505B3}>:
  Component #:QLOT/CLI not found
```

## Version
- Qlot v0.10.0