### PR TITLE
Add QLOT/UTIL nickname to QLOT/UTILS.

### DIFF
--- a/utils.lisp
+++ b/utils.lisp
@@ -1,4 +1,7 @@
 (defpackage #:qlot/utils
+  ;; QLOT/UTIL package is refered by some packages
+  ;; ex. https://github.com/inaimathi/cl-notebook/issues/71
+  (:nicknames #:qlot/util)
   (:use #:cl)
   (:export #:with-in-directory
            #:make-keyword


### PR DESCRIPTION
The old package name is refered by some libraries.
Fix https://github.com/inaimathi/cl-notebook/issues/71.

fixes #95 