### PR TITLE
Added an option "--no-deps".

### DIFF
--- a/cli.lisp
+++ b/cli.lisp
@@ -6,21 +6,24 @@
            #:extend-source-registry))
 (in-package #:qlot/cli)
 
-(defun install (&optional (object *default-pathname-defaults*))
+(defun install (&optional (object *default-pathname-defaults*) &rest args)
   (let ((*standard-output* (make-broadcast-stream))
         (*trace-output* (make-broadcast-stream)))
     (asdf:load-system :qlot/install))
-  (uiop:symbol-call '#:qlot/install '#:install-project
-                    (pathname (or object *default-pathname-defaults*))))
+  (destructuring-bind (&key install-deps) args
+    (uiop:symbol-call '#:qlot/install '#:install-project
+                      (pathname (or object *default-pathname-defaults*))
+                      :install-deps install-deps)))
 
 (defun update (&optional (object *default-pathname-defaults*) &rest args)
   (let ((*standard-output* (make-broadcast-stream))
         (*trace-output* (make-broadcast-stream)))
     (asdf:load-system :qlot/install))
-  (destructuring-bind (&key projects) args
+  (destructuring-bind (&key projects install-deps) args
     (uiop:symbol-call '#:qlot/install '#:update-project
                       (pathname (or object *default-pathname-defaults*))
-                      :projects projects)))
+                      :projects projects
+                      :install-deps install-deps)))
 
 (defun rename-quicklisp-to-dot-qlot (&optional (pwd *default-pathname-defaults*) enable-color)
   (fresh-line *error-output*)

--- a/roswell/qlot.ros
+++ b/roswell/qlot.ros
@@ -47,6 +47,8 @@ OPTIONS:
         Show the Qlot version
     --debug
         A flag to enable debug logging. (Only for 'install' or 'update')
+    --no-deps
+        Don't install dependencies of all systems from the current directory.
 "
           (file-namestring *load-pathname*)))
 
@@ -104,31 +106,37 @@ OPTIONS:
         (list sequence))))
 
 (defun parse-argv (argv)
-  (let ((target nil)
-        (projects '()))
-    (loop for option = (pop argv)
-          while option
-          do (case-equal option
-               ("--project"
-                 (unless argv
-                   (qlot/errors:ros-command-error "--project requires a project name"))
-                 (setf projects
-                       (append projects
-                               (remove ""
-                                       (split #\, (pop argv))
-                                       :test 'equal))))
-               ("--version"
-                 (print-version)
-                 (ros:quit))
-               ("--debug"
-                 (setf qlot/logger:*debug* t))
-               (otherwise
-                 (if target
-                     (qlot/errors:ros-command-error "'~A' is unknown option" option)
-                     (setf target option))))
-          finally
-          (return
-           (cons target (and projects (list :projects projects)))))))
+  (loop with target = nil
+        with projects = '()
+        with install-deps = t
+        for option = (pop argv)
+        while option
+        do (case-equal option
+             ("--project"
+              (unless argv
+                (qlot/errors:ros-command-error "--project requires a project name"))
+              (setf projects
+                    (append projects
+                            (remove ""
+                                    (split #\, (pop argv))
+                                    :test 'equal))))
+             ("--version"
+              (print-version)
+              (ros:quit))
+             ("--debug"
+              (setf qlot/logger:*debug* t))
+             ("--no-deps"
+              (setf install-deps nil))
+             (otherwise
+              (if target
+                  (qlot/errors:ros-command-error "'~A' is unknown option" option)
+                  (setf target option))))
+        finally
+           (return
+             (append (list target
+                           :install-deps install-deps)
+                     (when projects
+                       (list :projects projects))))))
 
 (defun main (&optional $1 &rest argv)
   (declare (ignorable argv))


### PR DESCRIPTION
This option turns off dependencies installation. In some cases, this can be useful. For example, `qlot install` may fail if some of the lisp files reference a missing package.

I already made attempt to fix such issue (https://github.com/fukamachi/qlot/pull/73) but @fukamachi said it should be fixed in 0.10.x version of Qlot. Now I see, there is still the possibility to encounter such an issue in some cases.

Here is a minimal setup to reproduce this issue:

```
mkdir test-qlot
cd test-qlot
echo '' > qlfile
echo '(defsystem "test" :class :package-inferred-system)' > test.asd
echo '(cl-fad:list-directory "")' > some.lisp
qlot install
```

This will produce the following error:

```
Unhandled SB-INT:SIMPLE-READER-PACKAGE-ERROR in thread #<SB-THREAD:THREAD "main thread" RUNNING
                                                          {10004F84C3}>:
  Package CL-FAD does not exist.

    Line: 1, Column: 21, File-Position: 21

    Stream: #<SB-SYS:FD-STREAM for "file /private/tmp/test-qlot/some.lisp" {100414C223}>

Backtrace for: #<SB-THREAD:THREAD "main thread" RUNNING {10004F84C3}>
0: (SB-DEBUG::DEBUGGER-DISABLED-HOOK #<SB-INT:SIMPLE-READER-PACKAGE-ERROR "Package ~A does not exist." {100414C443}> #<unused argument> :QUIT T)
1: (SB-DEBUG::RUN-HOOK SB-EXT:*INVOKE-DEBUGGER-HOOK* #<SB-INT:SIMPLE-READER-PACKAGE-ERROR "Package ~A does not exist." {100414C443}>)
2: (INVOKE-DEBUGGER #<SB-INT:SIMPLE-READER-PACKAGE-ERROR "Package ~A does not exist." {100414C443}>)
3: (ERROR #<SB-INT:SIMPLE-READER-PACKAGE-ERROR "Package ~A does not exist." {100414C443}>)
4: (SB-KERNEL:WITH-SIMPLE-CONDITION-RESTARTS ERROR NIL SB-INT:SIMPLE-READER-PACKAGE-ERROR :PACKAGE "CL-FAD" :STREAM #<SB-SYS:FD-STREAM for "file /private/tmp/test-qlot/some.lisp" {100414C223}> :FORMAT-CONTROL "Package ~A does not exist." :FORMAT-ARGUMENTS ("CL-FAD"))
5: (SB-IMPL::READER-FIND-PACKAGE "CL-FAD" #<SB-SYS:FD-STREAM for "file /private/tmp/test-qlot/some.lisp" {100414C223}> T)
6: (SB-IMPL::READ-TOKEN #<SB-SYS:FD-STREAM for "file /private/tmp/test-qlot/some.lisp" {100414C223}> #\c)
7: (SB-IMPL::READ-MAYBE-NOTHING #<SB-SYS:FD-STREAM for "file /private/tmp/test-qlot/some.lisp" {100414C223}> #\c)
8: (SB-IMPL::READ-LIST #<SB-SYS:FD-STREAM for "file /private/tmp/test-qlot/some.lisp" {100414C223}> #<unused argument>)
9: (SB-IMPL::READ-MAYBE-NOTHING #<SB-SYS:FD-STREAM for "file /private/tmp/test-qlot/some.lisp" {100414C223}> #\()
10: (SB-IMPL::%READ-PRESERVING-WHITESPACE #<SB-SYS:FD-STREAM for "file /private/tmp/test-qlot/some.lisp" {100414C223}> NIL (NIL) T)
11: (SB-IMPL::%READ-PRESERVING-WHITESPACE #<SB-SYS:FD-STREAM for "file /private/tmp/test-qlot/some.lisp" {100414C223}> NIL (NIL) NIL)
12: (READ #<SB-SYS:FD-STREAM for "file /private/tmp/test-qlot/some.lisp" {100414C223}> NIL NIL NIL)
13: (ASDF/PACKAGE-INFERRED-SYSTEM::STREAM-DEFPACKAGE-FORM #<SB-SYS:FD-STREAM for "file /private/tmp/test-qlot/some.lisp" {100414C223}>)
14: (UIOP/STREAM:CALL-WITH-INPUT-FILE #P"/private/tmp/test-qlot/some.lisp" #<FUNCTION (LAMBDA (ASDF/PACKAGE-INFERRED-SYSTEM::F) :IN ASDF/PACKAGE-INFERRED-SYSTEM::FILE-DEFPACKAGE-FORM) {2262D76B}> :ELEMENT-TYPE NIL :EXTERNAL-FORMAT NIL :IF-DOES-NOT-EXIST :ERROR)
15: (QLOT/UTILS/ASDF:LISP-FILE-DEPENDENCIES #P"/private/tmp/test-qlot/some.lisp")
16: (QLOT/INSTALL::INSTALL-DEPENDENCIES #P"/private/tmp/test-qlot/" #P"/private/tmp/test-qlot/.qlot/")
17: (QLOT/INSTALL:INSTALL-QLFILE #P"/private/tmp/test-qlot/qlfile" :QUICKLISP-HOME NIL :INSTALL-DEPS T)
18: (MAIN "install")
19: (SB-INT:SIMPLE-EVAL-IN-LEXENV (APPLY (QUOTE MAIN) ROSWELL:*ARGV*) #<NULL-LEXENV>)
20: (SB-INT:SIMPLE-EVAL-IN-LEXENV (ROSWELL:QUIT (APPLY (QUOTE MAIN) ROSWELL:*ARGV*)) #<NULL-LEXENV>)
21: (SB-EXT:EVAL-TLF (ROSWELL:QUIT (APPLY (QUOTE MAIN) ROSWELL:*ARGV*)) NIL NIL)
22: ((LABELS SB-FASL::EVAL-FORM :IN SB-INT:LOAD-AS-SOURCE) (ROSWELL:QUIT (APPLY (QUOTE MAIN) ROSWELL:*ARGV*)) NIL)
23: (SB-INT:LOAD-AS-SOURCE #<CONCATENATED-STREAM :STREAMS NIL {10036B0733}> :VERBOSE NIL :PRINT NIL :CONTEXT "loading")
24: ((FLET SB-FASL::THUNK :IN LOAD))
25: (SB-FASL::CALL-WITH-LOAD-BINDINGS #<CLOSURE (FLET SB-FASL::THUNK :IN LOAD) {19FF4EB}> #<CONCATENATED-STREAM :STREAMS NIL {10036B0733}>)
26: ((FLET SB-FASL::LOAD-STREAM :IN LOAD) #<CONCATENATED-STREAM :STREAMS NIL {10036B0733}> NIL)
27: (LOAD #<CONCATENATED-STREAM :STREAMS NIL {10036B0733}> :VERBOSE NIL :PRINT NIL :IF-DOES-NOT-EXIST T :EXTERNAL-FORMAT :DEFAULT)
28: ((FLET ROSWELL::BODY :IN ROSWELL:SCRIPT) #<SB-SYS:FD-STREAM for "file /Users/art/.roswell/local-projects/fukamachi/qlot/roswell/qlot.ros" {10036ABCB3}>)
29: (ROSWELL:SCRIPT "/Users/art/.roswell/bin/qlot" "install")
30: (ROSWELL:RUN ((:EVAL "(ros:asdf)") (:EVAL "(ros:quicklisp)") (:SCRIPT "/Users/art/.roswell/bin/qlot" "install") (:QUIT NIL)))
31: (SB-INT:SIMPLE-EVAL-IN-LEXENV (ROSWELL:RUN (QUOTE ((:EVAL "(ros:asdf)") (:EVAL "(ros:quicklisp)") (:SCRIPT "/Users/art/.roswell/bin/qlot" "install") (:QUIT NIL)))) #<NULL-LEXENV>)
32: (EVAL (ROSWELL:RUN (QUOTE ((:EVAL "(ros:asdf)") (:EVAL "(ros:quicklisp)") (:SCRIPT "/Users/art/.roswell/bin/qlot" "install") (:QUIT NIL)))))
33: (SB-IMPL::PROCESS-EVAL/LOAD-OPTIONS ((:EVAL . "(progn #-ros.init(cl:load \"/usr/local/etc/roswell/init.lisp\"))") (:EVAL . "(ros:run '((:eval\"(ros:asdf)\")(:eval\"(ros:quicklisp)\")(:script \"/Users/art/.roswell/bin/qlot\"\"install\")(:quit ())))")))
34: (SB-IMPL::TOPLEVEL-INIT)
35: ((FLET SB-UNIX::BODY :IN SB-EXT:SAVE-LISP-AND-DIE))
36: ((FLET "WITHOUT-INTERRUPTS-BODY-14" :IN SB-EXT:SAVE-LISP-AND-DIE))
37: ((LABELS SB-IMPL::RESTART-LISP :IN SB-EXT:SAVE-LISP-AND-DIE))
```

However you can skip installation of the dependencies now:

```
$ qlot install --no-deps
Reading '/private/tmp/test-qlot/qlfile'...
Already have dist "quicklisp" version "2019-11-30".
Successfully installed.
```