### PR TITLE
avoid read error in 'qlot install'

### DIFF
--- a/utils/asdf.lisp
+++ b/utils/asdf.lisp
@@ -140,5 +140,5 @@
                 append (directory-lisp-files subdir))))
 
 (defun lisp-file-dependencies (file)
-  (when (asdf/package-inferred-system::file-defpackage-form file)
+  (when (ignore-errors (asdf/package-inferred-system::file-defpackage-form file))
     (asdf/package-inferred-system::package-inferred-system-file-dependencies file)))


### PR DESCRIPTION
`$ qlot install` をしたときにそのディレクトリ以下にread errorが起こるlispファイルがあると途中で中断してしまう問題があり、それを回避するようにしました。