### PR TITLE
Allow to load libraries having defsystem dependencies which don't in Quicklisp

### DIFF
--- a/install.lisp
+++ b/install.lisp
@@ -24,6 +24,7 @@
                 #:with-quicklisp-home)
   (:import-from #:qlot/utils/asdf
                 #:with-directory
+                #:with-autoload-on-missing
                 #:directory-lisp-files
                 #:lisp-file-dependencies)
   (:import-from #:qlot/errors
@@ -50,6 +51,12 @@
     (with-quicklisp-home qlhome
       (let ((all-dependencies '()))
         (with-directory (system-file system-name dependencies) project-root
+          (message "Loading '~A'..." system-file)
+          (let ((*standard-output* (make-broadcast-stream))
+                (*trace-output* (make-broadcast-stream))
+                (*error-output* (make-broadcast-stream)))
+            (with-autoload-on-missing
+              (asdf:load-asd system-file)))
           (when (typep (asdf:find-system system-name) 'asdf:package-inferred-system)
             (let ((pis-dependencies
                     (loop for file in (directory-lisp-files project-root)

--- a/utils/asdf.lisp
+++ b/utils/asdf.lisp
@@ -21,7 +21,7 @@
         (e (gensym)))
     `(let ((,retrying (make-hash-table :test 'equal)))
        (#+asdf3.3 asdf/session:with-asdf-session #+asdf3.3 (:override t)
-        #-asdf3.3 tagbody #-asdf3.3 retry
+        #-asdf3.3 progn
          (handler-bind ((asdf:missing-component
                           (lambda (,e)
                             (unless (gethash (asdf::missing-requires ,e) ,retrying)
@@ -30,10 +30,7 @@
                                 (uiop:symbol-call '#:ql-dist '#:ensure-installed
                                                   (uiop:symbol-call '#:ql-dist '#:find-system
                                                                     (asdf::missing-requires ,e)))
-                                #+asdf3.3
-                                (invoke-restart (find-restart 'asdf:clear-configuration-and-retry ,e))
-                                #-asdf3.3
-                                (go retry))))))
+                                (invoke-restart (find-restart 'asdf:retry ,e)))))))
            ,@body)))))
 
 (defun directory-system-files (directory)


### PR DESCRIPTION
This is found when installing a system whose ASD file depends on cl-debug-print (not in Quicklisp yet).