### PR TITLE
Output more info instead SB-PCL::NO-APPLICABLE-METHOD-ERROR when using custom quickdist source with wrong name

### DIFF
--- a/install.lisp
+++ b/install.lisp
@@ -277,9 +277,15 @@ qlot exec /bin/sh \"$CURRENT/../~A\" \"$@\"
                      (debug-log "Using temporary directory '~A'" tmp-dir)
                      (update-source source tmp-dir))))))))
         (with-quicklisp-home qlhome
-          (with-package-functions #:ql-dist (dist (setf preference))
-            (setf (preference (dist (source-dist-name source)))
-                  (incf preference)))))
+          (with-package-functions #:ql-dist (dist name all-dists (setf preference))
+            (let* ((dist-name (source-dist-name source))
+                   (dist (dist dist-name)))
+              (unless dist
+                (error "Unable to find dist with name ~S. You should use one of these names in the qlfile: ~A"
+                       dist-name
+                       (mapcar #'name (all-dists))))
+              (setf (preference dist)
+                    (incf preference))))))
       (with-quicklisp-home qlhome
         (with-package-functions #:ql-dist (uninstall name all-dists)
           (dolist (dist (all-dists))


### PR DESCRIPTION
When you are using a distribution name different from the name in it's metadata, qlot returned this error:

```
Unhandled SB-PCL::NO-APPLICABLE-METHOD-ERROR in thread #<SB-THREAD:THREAD "main thread" RUNNING
                                                          {10004F84C3}>:
  There is no applicable method for the generic function
    #<STANDARD-GENERIC-FUNCTION QL-DIST:BASE-DIRECTORY (3)>
  when called with arguments
    (NIL).
See also:
  The ANSI Standard, Section 7.6.6

Backtrace for: #<SB-THREAD:THREAD "main thread" RUNNING {10004F84C3}>
0: (SB-DEBUG::DEBUGGER-DISABLED-HOOK #<SB-PCL::NO-APPLICABLE-METHOD-ERROR {1004D471A3}> #<unused argument> :QUIT T)
1: (SB-DEBUG::RUN-HOOK SB-EXT:*INVOKE-DEBUGGER-HOOK* #<SB-PCL::NO-APPLICABLE-METHOD-ERROR {1004D471A3}>)
2: (INVOKE-DEBUGGER #<SB-PCL::NO-APPLICABLE-METHOD-ERROR {1004D471A3}>)
3: (ERROR SB-PCL::NO-APPLICABLE-METHOD-ERROR :GENERIC-FUNCTION #<STANDARD-GENERIC-FUNCTION QL-DIST:BASE-DIRECTORY (3)> :ARGS (NIL))
4: ((:METHOD NO-APPLICABLE-METHOD (T)) #<STANDARD-GENERIC-FUNCTION QL-DIST:BASE-DIRECTORY (3)> NIL) [fast-method]
5: (SB-PCL::CALL-NO-APPLICABLE-METHOD #<STANDARD-GENERIC-FUNCTION QL-DIST:BASE-DIRECTORY (3)> (NIL))
6: ((:METHOD QL-DIST:RELATIVE-TO (T T)) NIL "preference.txt") [fast-method]
7: ((:METHOD (SETF QL-DIST:PREFERENCE) (T T)) 3796788222 NIL) [fast-method]
8: (QLOT/INSTALL::APPLY-QLFILE-TO-QLHOME #P"/Users/art/projects/lisp/foo/qlfile" #P"/Users/art/projects/lisp/foo/.qlot/" :IGNORE-LOCK NIL :PROJECTS NIL)
9: (QLOT/INSTALL:INSTALL-QLFILE #P"/Users/art/projects/lisp/foo/qlfile" :QUICKLISP-HOME NIL :INSTALL-DEPS NIL)
10: (MAIN "install" "--no-deps")
```

To reproduce this issue, you might create a qlfile with this content:

dist borodust http://bodge.borodust.org/dist/org.borodust.bodge.txt

This fix makes error more explicit:

Unable to find dist with name "borodust". You should use one of these names in the qlfile: ("quicklisp" "org.borodust.bodge")