### PR TITLE
Fix handling of projects with names containing uppercase letters

### DIFF
--- a/install.lisp
+++ b/install.lisp
@@ -277,8 +277,8 @@ qlot exec /bin/sh \"$CURRENT/../~A\" \"$@\"
                      (debug-log "Using temporary directory '~A'" tmp-dir)
                      (update-source source tmp-dir))))))))
         (with-quicklisp-home qlhome
-          (with-package-functions #:ql-dist (dist (setf preference))
-            (setf (preference (dist (source-dist-name source)))
+          (with-package-functions #:ql-dist (find-dist (setf preference))
+            (setf (preference (find-dist (source-dist-name source)))
                   (incf preference)))))
       (with-quicklisp-home qlhome
         (with-package-functions #:ql-dist (uninstall name all-dists)


### PR DESCRIPTION
Dist installation creates case sensitive path / folder for dist. But (ql-dist:dist string) method downcases string before lookup. That causes the following error:

```
Already have dist "Shinmera-plump" version "ultralisp-20200615113009".
Unhandled SB-PCL::NO-APPLICABLE-METHOD-ERROR in thread #<SB-THREAD:THREAD "main thread" RUNNING
                                                          {10012E0613}>:
  There is no applicable method for the generic function
    #<STANDARD-GENERIC-FUNCTION QL-DIST:BASE-DIRECTORY (3)>
  when called with arguments
    (NIL).
See also:
  The ANSI Standard, Section 7.6.6
```

This breaks some Ultralisp dependencies.

Using FIND-DIST as it is not doing string downcase to dist name.