### PR TITLE
Allow using custom dists which names where name contains /

### DIFF
--- a/distify/dist.lisp
+++ b/distify/dist.lisp
@@ -20,11 +20,19 @@
     (setf (source-distinfo-url source)
           (get-distinfo-url (source-distribution source)
                             (slot-value source 'qlot/source/dist::%version))))
-  (let ((destination (truename destination)))
+  (let* ((destination (truename destination))
+         (relative-path
+           ;; distribution name may include slashes
+           ;; and can't be used directly as a name
+           ;; of a pathname.
+           (uiop:parse-unix-namestring (source-project-name source)
+                                       :type "txt"))
+         (target-path (merge-pathnames
+                       relative-path
+                       destination)))
+    (ensure-directories-exist target-path)
     (dex:fetch (source-distinfo-url source)
-               (make-pathname :name (source-project-name source)
-                              :type "txt"
-                              :defaults destination)
+               target-path
                :if-exists :supersede
                :proxy *proxy*)
     destination))


### PR DESCRIPTION
This also requies a fixed Quicklisp client with
changes from this pull-request:

https://github.com/quicklisp/quicklisp-client/pull/206

Here is example qlfile where the custom distribution with
forked libs takes precedence over Ultralisp and Quicklisp:

    dist ultralisp http://dist.ultralisp.org/
    dist svetlyak40wt/my-forks http://dist.ultralisp.org/svetlyak40wt/my-forks.txt