### PR TITLE
Fixed the issue when Qlot failed to download Quicklisp installer.

### DIFF
--- a/proxy.lisp
+++ b/proxy.lisp
@@ -9,19 +9,33 @@
 
 #+quicklisp
 (eval-when (:compile-toplevel :load-toplevel :execute)
+  ;; Previously, this wrapper was defined in the next
+  ;; eval-when block as a lambda form.
+  ;; 
+  ;; But this caused issue when loading cached
+  ;; files:
+  ;; https://github.com/fukamachi/qlot/issues/104
+  ;; 
+  ;; For some reason, a separate function definition
+  ;; works as expected.
+  (defun qlot-http-fetch (url &rest rest)
+    (let ((ql:*proxy-url*
+            (if (eql (search #1="qlot://localhost/" url
+                             :end2 (length #1#))
+                     0)
+                nil
+                ql:*proxy-url*)))
+      (apply #'orig-http-fetch url rest))))
+
+#+quicklisp
+(eval-when (:compile-toplevel :load-toplevel :execute)
   (unless (fboundp 'orig-http-fetch)
     ;; dummy for suppress style warning
     (defun orig-http-fetch (&rest args)
       (declare (ignore args)))
-    (setf (symbol-function 'orig-http-fetch) (fdefinition
-                                               (find-symbol (string '#:http-fetch) '#:ql-http)))
+    (setf (symbol-function 'orig-http-fetch)
+          (fdefinition
+           (find-symbol (string '#:http-fetch) '#:ql-http)))
     ;; do not use proxy if connect localhost
     (setf (fdefinition (find-symbol (string '#:http-fetch) '#:ql-http))
-          (lambda (url &rest rest)
-            (let ((ql:*proxy-url*
-                    (if (eql (search #1="qlot://localhost/" url
-                                     :end2 (length #1#))
-                             0)
-                        nil
-                        ql:*proxy-url*)))
-              (apply #'orig-http-fetch url rest))))))
+          #'qlot-http-fetch)))


### PR DESCRIPTION
This commit closes issue https://github.com/fukamachi/qlot/issues/104

For some reason, code loaded from the fasl file, wrapper code
called a dummy function ORIG-HTTP-FETCH instead of
a real original function saved to the symbol function.

I don't really understand the reason this strange bug, but
separating a wrapper definition helped to solve this problem.

Tested on SBCL 2.1.2 under OSX.