### PR TITLE
Add 'bundle' subcommand

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -101,6 +101,11 @@ COMMANDS:
     exec [shell-args..]
         Invokes the following shell-command with the project local Quicklisp.
 
+    bundle
+        Bundles project dependencies to './.bundle-libs'.
+        Load './.bundle-libs/bundle.lisp' to make them available.
+        Read https://www.quicklisp.org/beta/bundles.html for the detail.
+
 OPTIONS:
     --version
         Show the Qlot version

--- a/bundle.lisp
+++ b/bundle.lisp
@@ -1,0 +1,41 @@
+(defpackage #:qlot/bundle
+  (:use #:cl)
+  (:import-from #:qlot/utils/project
+                #:project-dependencies
+                #:local-quicklisp-installed-p
+                #:local-quicklisp-home)
+  (:import-from #:qlot/utils/ql
+                #:with-quicklisp-home)
+  (:import-from #:qlot/utils
+                #:with-package-functions)
+  (:import-from #:qlot/logger
+                #:message)
+  (:import-from #:qlot/errors
+                #:qlot-simple-error)
+  (:export #:bundle-project))
+(in-package #:qlot/bundle)
+
+(defvar *bundle-directory* #P".bundle-libs/")
+
+(defun bundle-project (project-root)
+  (assert (uiop:absolute-pathname-p project-root))
+
+  (unless (local-quicklisp-installed-p project-root)
+    (error 'qlot-simple-error
+           :format-control "Local Quicklisp is not installed yet."))
+
+  (let ((quicklisp-home (local-quicklisp-home project-root)))
+    (unless (find-package '#:ql)
+      (load (merge-pathnames #P"setup.lisp" quicklisp-home)))
+
+    (with-quicklisp-home quicklisp-home
+      (let ((dependencies (project-dependencies project-root))
+            (bundle-directory (merge-pathnames *bundle-directory* project-root)))
+        (when dependencies
+          (message "Bundling ~D ~:*dependenc~[ies~;y~:;ies~]..." (length dependencies))
+          (with-package-functions #:ql-dist (name)
+            (let ((dependency-names (mapcar #'name dependencies)))
+              (with-package-functions #:ql (bundle-systems)
+                (bundle-systems dependency-names
+                                :to bundle-directory))))
+          (message "Successfully bundled at '~A'." bundle-directory))))))

--- a/bundle.lisp
+++ b/bundle.lisp
@@ -17,7 +17,7 @@
 
 (defvar *bundle-directory* #P".bundle-libs/")
 
-(defun bundle-project (project-root)
+(defun %bundle-project (project-root)
   (assert (uiop:absolute-pathname-p project-root))
 
   (unless (local-quicklisp-installed-p project-root)
@@ -39,3 +39,12 @@
                 (bundle-systems dependency-names
                                 :to bundle-directory))))
           (message "Successfully bundled at '~A'." bundle-directory))))))
+
+(defun bundle-project (object)
+  (etypecase object
+    ((or symbol string)
+     (bundle-project (asdf:find-system object)))
+    (asdf:system
+      (%bundle-project (asdf:system-source-directory object)))
+    (pathname
+      (%bundle-project object))))

--- a/cli.lisp
+++ b/cli.lisp
@@ -10,6 +10,7 @@
   (:export #:install
            #:update
            #:add
+           #:bundle
            #:main))
 (in-package #:qlot/cli)
 
@@ -56,6 +57,15 @@
       (format out "~&~{~A~^ ~}~%" args)
       (message "Add '~{~A~^ ~}' to '~A'." args qlfile)))
   (install))
+
+(defun bundle (&optional (project-root *default-pathname-defaults*) &rest args)
+  (declare (ignore args))
+  (unless (find-package :qlot/bundle)
+    (let ((*standard-output* (make-broadcast-stream))
+          (*trace-output* (make-broadcast-stream)))
+      (asdf:load-system :qlot/bundle)))
+  (uiop:symbol-call '#:qlot/bundle '#:bundle-project
+                    (uiop:ensure-directory-pathname project-root)))
 
 (defun rename-quicklisp-to-dot-qlot (&optional (pwd *default-pathname-defaults*) enable-color)
   (fresh-line *error-output*)
@@ -163,6 +173,11 @@ COMMANDS:
     exec [shell-args..]
         Invokes the following shell-command with the project local Quicklisp.
 
+    bundle
+        Bundles project dependencies to './.bundle-libs'.
+        Load './.bundle-libs/bundle.lisp' to make them available.
+        Read https://www.quicklisp.org/beta/bundles.html for the detail.
+
 OPTIONS:
     --version
         Show the Qlot version
@@ -261,6 +276,8 @@ OPTIONS:
              (unless argv
                (qlot/errors:ros-command-error "requires a new library information."))
              (add argv))
+            ((equal "bundle" $1)
+             (apply #'bundle argv))
             ((equal "--version" $1)
              (print-version)
              (uiop:quit -1))

--- a/distify/git.lisp
+++ b/distify/git.lisp
@@ -20,9 +20,6 @@
                 #:git-clone
                 #:git-ref
                 #:create-git-tarball)
-  (:import-from #:qlot/utils/asdf
-                #:with-directory
-                #:directory-system-files)
   (:import-from #:qlot/utils/archive
                 #:extract-tarball)
   (:import-from #:qlot/utils/tmp

--- a/main.lisp
+++ b/main.lisp
@@ -6,6 +6,8 @@
                 #:update-project
                 #:*qlot-directory*
                 #:*default-qlfile*)
+  (:import-from #:qlot/bundle
+                #:bundle-project)
   (:import-from #:qlot/logger
                 #:*debug*
                 #:*logger-message-stream*
@@ -19,6 +21,7 @@
            #:update
            #:with-local-quicklisp
            #:quickload
+           #:bundle
            #:*proxy*
            #:*debug*
            #:*logger-message-stream*
@@ -109,3 +112,6 @@
     (dolist (system systems systems)
       (with-local-quicklisp (system)
         (apply #'uiop:symbol-call '#:ql '#:quickload system args)))))
+
+(defun bundle (object)
+  (bundle-project object))

--- a/utils/project.lisp
+++ b/utils/project.lisp
@@ -1,0 +1,82 @@
+(defpackage #:qlot/utils/project
+  (:use #:cl)
+  (:import-from #:qlot/utils/asdf
+                #:with-directory
+                #:with-autoload-on-missing
+                #:directory-lisp-files
+                #:lisp-file-dependencies)
+  (:import-from #:qlot/utils
+                #:with-package-functions)
+  (:import-from #:qlot/logger
+                #:message
+                #:debug-log)
+  (:export #:*qlot-directory*
+           #:local-quicklisp-installed-p
+           #:local-quicklisp-home
+           #:project-dependencies))
+(in-package #:qlot/utils/project)
+
+(defvar *qlot-directory* #P".qlot/")
+(defvar *default-qlfile* #P"qlfile")
+
+(defun local-quicklisp-installed-p (project-root)
+  (let ((qlhome (merge-pathnames *qlot-directory* project-root)))
+    (when (and (uiop:directory-exists-p qlhome)
+               (uiop:file-exists-p (merge-pathnames "setup.lisp" qlhome)))
+      qlhome)))
+
+(defun local-quicklisp-home (project-root)
+  (let ((project-root (uiop:ensure-directory-pathname project-root)))
+    (uiop:ensure-absolute-pathname
+      (merge-pathnames *qlot-directory* project-root))))
+
+(defun project-dependencies (project-root)
+  (with-package-functions #:ql-dist (find-system name)
+    (let ((all-dependencies '())
+          (loaded-asd-files '())
+          (project-system-names '()))
+      (with-directory (system-file system-name dependencies) project-root
+        (pushnew system-name project-system-names :test 'equal)
+        (unless (find system-file loaded-asd-files :test 'equal)
+          (push system-file loaded-asd-files)
+          (message "Loading '~A'..." system-file)
+          (let ((*standard-output* (make-broadcast-stream))
+                (*trace-output* (make-broadcast-stream))
+                (*error-output* (make-broadcast-stream)))
+            (with-autoload-on-missing
+              (asdf:load-asd system-file))))
+        (when (typep (asdf:find-system system-name) 'asdf:package-inferred-system)
+          (let ((pis-dependencies
+                  (loop for file in (directory-lisp-files project-root)
+                        append (lisp-file-dependencies file))))
+            (setf dependencies
+                  (delete-duplicates
+                    (nconc dependencies pis-dependencies)
+                    :test 'equal))))
+        (let ((dependencies (remove-if-not #'find-system dependencies)))
+          (debug-log "'~A' requires ~S" system-name dependencies)
+          (setf all-dependencies
+                (nconc all-dependencies
+                       (remove-if-not #'find-system dependencies)))))
+      (with-package-functions #:ql-dist (required-systems name)
+        (let ((already-seen (make-hash-table :test 'equal)))
+          (labels ((find-system-with-fallback (system-name)
+                     (or (find-system system-name)
+                         (find-system (asdf:primary-system-name system-name))))
+                   (system-dependencies (system-name)
+                     (unless (gethash system-name already-seen)
+                       (setf (gethash system-name already-seen) t)
+                       (let ((system (find-system-with-fallback system-name)))
+                         (when system
+                           (cons system
+                                 (mapcan #'system-dependencies (copy-seq (required-systems system)))))))))
+            (setf all-dependencies
+                  (delete-duplicates
+                    (loop for dependency in all-dependencies
+                          append (system-dependencies dependency))
+                    :key #'name
+                    :test 'string=)))))
+
+      (remove-if (lambda (dep)
+                   (find (name dep) project-system-names :test 'equal))
+                 all-dependencies))))

--- a/utils/ql.lisp
+++ b/utils/ql.lisp
@@ -93,10 +93,6 @@
     (parse-space-delimited-stream in :test test :include-header include-header)))
 
 (defmacro with-quicklisp-home (qlhome &body body)
-  (let ((g-qlhome (gensym "QLHOME")))
-    `(let ((,g-qlhome ,qlhome))
-       (assert (and (uiop:directory-exists-p ,g-qlhome)
-                    (uiop:file-exists-p (merge-pathnames "setup.lisp" ,g-qlhome))))
-       (progv (list (intern #.(string :*quicklisp-home*) :ql))
-           (list ,g-qlhome)
-         ,@body))))
+  `(progv (list (intern #.(string :*quicklisp-home*) :ql))
+       (list ,qlhome)
+     ,@body))

--- a/utils/ql.lisp
+++ b/utils/ql.lisp
@@ -93,6 +93,10 @@
     (parse-space-delimited-stream in :test test :include-header include-header)))
 
 (defmacro with-quicklisp-home (qlhome &body body)
-  `(progv (list (intern #.(string :*quicklisp-home*) :ql))
-       (list ,qlhome)
-     ,@body))
+  (let ((g-qlhome (gensym "QLHOME")))
+    `(let ((,g-qlhome ,qlhome))
+       (assert (and (uiop:directory-exists-p ,g-qlhome)
+                    (uiop:file-exists-p (merge-pathnames "setup.lisp" ,g-qlhome))))
+       (progv (list (intern #.(string :*quicklisp-home*) :ql))
+           (list ,g-qlhome)
+         ,@body))))


### PR DESCRIPTION
`qlot bundle` dumps all project dependencies into '.bundle-libs/' and makes them available without Qlot and Quicklisp.

This feature is achieved with `ql:bundle-systems`.
See https://www.quicklisp.org/beta/bundles.html for the detail.