### PR TITLE
Fix for `qlot exec ...` command

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -16,6 +16,7 @@ case "$command" in
     check_qlot_directory
     QUICKLISP_HOME=.qlot/
     CL_SOURCE_REGISTRY="$(pwd)/"
+    shift
     exec "$@"
     ;;
   run)


### PR DESCRIPTION
Before the change, the following error occurred.

```
$ qlot exec
/home/user/.qlot/qlot/scripts/run.sh: line 19: exec: exec: not found
```
