### PR TITLE
setup: suppress output from cd

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-QLOT_SOURCE_DIR=$(cd "$(dirname "$0")/../" && pwd -P)
+QLOT_SOURCE_DIR=$(cd "$(dirname "$0")/../" 2>&1 >/dev/null && pwd -P)
 
 errmsg() { echo -e "\e[31mError: $1\e[0m" >&2; }
 if [ "$(which sbcl)" != "" ]; then


### PR DESCRIPTION
Some users' settings will print the directory that `cd` changes into, so
we redirect all output unconditionally to /dev/null.