### PR TITLE
Prevent errors when collecting dependencies of package-inferred-system.

### DIFF
--- a/utils/asdf.lisp
+++ b/utils/asdf.lisp
@@ -198,7 +198,10 @@
            (if (listp object)
                (car object)
                object)))
-    (let* ((defpackage-form (asdf/package-inferred-system::file-defpackage-form file))
+    (let* ((defpackage-form
+               ;; Prevent errors when loading a file without defpackage form
+               (ignore-errors
+                 (asdf/package-inferred-system::file-defpackage-form file)))
            (defpackage-form (remove-if (lambda (key)
                                          (find key '(:local-nicknames :lock)
                                                :test 'equal))


### PR DESCRIPTION
It may raise a read error when looking for defpackage form of non package files.