### PR TITLE
Use HTTPS when running ql:quickload

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -83,7 +83,7 @@ This is what Qlot is trying to solve.
 $ curl -L https://qlot.tech/installer | bash
 ```
 
-It requires `curl` and `sbcl` (or `ros`).
+It also requires `curl` and `tar`.
 
 To uninstall Qlot, run a Qlot uninstaller like:
 
@@ -93,7 +93,7 @@ $ ~/.qlot/qlot/scripts/qlot-uninstaller.sh
 
 ### via Roswell
 
-If you're already using Roswell, this is the easiest way to install Qlot.
+If you're already using Roswell, Qlot can be installed by `ros install`.
 
 ```shell
 $ ros install qlot              # Install from the Quicklisp dist
@@ -111,7 +111,7 @@ Run `ros update qlot` to update Qlot.
 
 ### via Quicklisp
 
-If [Quicklisp](https://www.quicklisp.org/) is set up on your home directory, this is the best way to install Qlot.
+If [Quicklisp](https://www.quicklisp.org/) is set up on your home directory, Qlot can be installed by `ql:quickload`.
 
 ```shell
 $ sbcl --noinform --eval '(ql:quickload (list :qlot :qlot/distify))' --quit
@@ -121,7 +121,7 @@ $ sudo chmod u+x /usr/local/bin/qlot
 
 To update Qlot, run `(ql:update-all-dists)` in the REPL.
 
-### Install from source
+### Manual installation
 
 If you don't use both of Roswell and Quicklisp for some reason, Qlot also can be installed from the source code.
 

--- a/fetch.lisp
+++ b/fetch.lisp
@@ -1,0 +1,35 @@
+(defpackage #:qlot/fetch
+  (:use #:cl)
+  (:import-from #:qlot/utils/http)
+  (:import-from #:qlot/utils/cli
+                #:command-line-arguments))
+(in-package #:qlot/fetch)
+
+(defun file-size (file)
+  (with-open-file (in file :element-type '(unsigned-byte 8))
+    (file-length in)))
+
+;; TODO: show progress
+(defun fetch-file (url file)
+  (ensure-directories-exist file)
+  (format t "~&; Fetching '~A'.~%" url)
+  (let ((now (get-internal-real-time)))
+    (qdex:fetch url file)
+    (format t "~&; Done '~A' (~$KB) in ~A seconds.~%"
+            (file-namestring file)
+            (/ (file-size file) 1024)
+            (coerce
+             (/ (- (get-internal-real-time) now)
+                internal-time-units-per-second)
+             'float)))
+  file)
+
+(defun main ()
+  (destructuring-bind (&optional $0 $1 &rest argv)
+      (command-line-arguments)
+    (let ((args (if (equal $1 "--")
+                    argv
+                    (cons $1 argv))))
+      (unless (= (length args) 2)
+        (format *error-output* "~&Error: Invalid number of arguments.~%"))
+      (apply #'fetch-file args))))

--- a/fetch.lisp
+++ b/fetch.lisp
@@ -9,12 +9,39 @@
   (with-open-file (in file :element-type '(unsigned-byte 8))
     (file-length in)))
 
-;; TODO: show progress
-(defun fetch-file (url file)
+(defun fetch-file (url file &rest args &key quietly &allow-other-keys)
+  (declare (ignore args))
   (ensure-directories-exist file)
   (format t "~&; Fetching '~A'.~%" url)
   (let ((now (get-internal-real-time)))
-    (qdex:fetch url file)
+    (multiple-value-bind (body-stream status headers)
+        (qdex:get url :want-stream t :force-binary t)
+      (declare (ignore status))
+      (let* ((body-size (gethash "content-length" headers))
+             (body-size (and body-size
+                             (ignore-errors
+                               (parse-integer body-size))))
+             (buffer (make-array 1024 :element-type '(unsigned-byte 8)))
+             (current-read-bytes 0)
+             (current-progress 0)
+             (width 80))
+        (with-open-file (out file
+                             :if-exists :supersede
+                             :if-does-not-exist :create
+                             :element-type '(unsigned-byte 8)
+                             :direction :output)
+          (loop for read-bytes = (read-sequence buffer body-stream)
+                until (zerop read-bytes)
+                do (incf current-read-bytes read-bytes)
+                   (write-sequence buffer out :end read-bytes)
+                   (when (and body-size (not quietly))
+                     (let ((new-progress (round
+                                          (* width
+                                             (max 1.0
+                                                  (/ current-read-bytes body-size))))))
+                       (loop repeat (- new-progress current-progress)
+                             do (write-char #\#))
+                       (setf current-progress new-progress)))))))
     (format t "~&; Done '~A' (~$KB) in ~A seconds.~%"
             (file-namestring file)
             (/ (file-size file) 1024)
@@ -27,6 +54,7 @@
 (defun main ()
   (destructuring-bind (&optional $0 $1 &rest argv)
       (command-line-arguments)
+    (declare (ignore $0))
     (let ((args (if (equal $1 "--")
                     argv
                     (cons $1 argv))))

--- a/local-init/https.lisp
+++ b/local-init/https.lisp
@@ -3,8 +3,9 @@
 (in-package #:qlot/local-init/https)
 
 (defvar *fetch-script*
-  (uiop:native-namestring
-   (asdf:system-relative-pathname :qlot #P"scripts/fetch.sh")))
+  (and (asdf:find-system :qlot nil)
+       (uiop:native-namestring
+        (asdf:system-relative-pathname :qlot #P"scripts/fetch.sh"))))
 
 (defun https-of (url)
   (if (and (stringp url)
@@ -46,18 +47,14 @@
                'float)))))
 
 (defun add-to-fetch-scheme-functions ()
-  (let* ((preference (uiop:getenv "QLOT_FETCH"))
-         (fn (cond
-               ((and (or (null preference)
-                         (equal preference "dexador"))
-                     (and (uiop:file-exists-p *fetch-script*)
-                          (uiop:file-exists-p
-                           (asdf:system-relative-pathname :qlot #P".qlot/setup.lisp"))))
-                'run-fetch)
-               ((and (or (null preference)
-                         (equal preference "curl"))
-                     (which "curl"))
-                'curl-fetch))))
+  (let ((fn (cond
+              ((and *fetch-script*
+                    (uiop:file-exists-p *fetch-script*)
+                    (uiop:file-exists-p
+                     (asdf:system-relative-pathname :qlot #P".qlot/setup.lisp")))
+               'run-fetch)
+              ((which "curl")
+               'curl-fetch))))
     (when fn
       (setf ql-http:*fetch-scheme-functions*
             (append `(("https" . ,fn)

--- a/local-init/https.lisp
+++ b/local-init/https.lisp
@@ -21,13 +21,42 @@
                     :output :interactive
                     :error-output :interactive))
 
+(defun which (cmd)
+  (handler-case
+      (string-right-trim '(#\Newline)
+                         (with-output-to-string (s)
+                           (uiop:run-program `("which" ,cmd)
+                                             :output s)))
+    (uiop/run-program:subprocess-error ()
+      nil)))
+
+(defun curl-fetch (url file &rest args)
+  (declare (ignore args))
+  (let ((url (https-of url)))
+    (format t "~&; Fetching '~A'.~%" url)
+    (let ((now (get-internal-real-time)))
+      (uiop:run-program (list "curl" "-sSL" url "-o" (uiop:native-namestring file))
+                        :error-output :interactive)
+      (format t "~&; Done '~A' (~$KB) in ~A seconds.~%"
+              (file-namestring file)
+              (/ (ql-util:file-size file) 1024)
+              (coerce
+               (/ (- (get-internal-real-time) now)
+                  internal-time-units-per-second)
+               'float)))))
+
 (defun add-to-fetch-scheme-functions ()
-  (when (and (uiop:file-exists-p *fetch-script*)
-             (uiop:file-exists-p
-              (asdf:system-relative-pathname :qlot #P".qlot/setup.lisp")))
-    (setf ql-http:*fetch-scheme-functions*
-          (append '(("https" . run-fetch)
-                    ("http" . run-fetch))
-                  ql-http:*fetch-scheme-functions*))))
+  (let ((fn (cond
+              ((and (uiop:file-exists-p *fetch-script*)
+                    (uiop:file-exists-p
+                     (asdf:system-relative-pathname :qlot #P".qlot/setup.lisp")))
+               'run-fetch)
+              ((which "curl")
+               'curl-fetch))))
+    (when fn
+      (setf ql-http:*fetch-scheme-functions*
+            (append `(("https" . ,fn)
+                      ("http" . ,fn))
+                    ql-http:*fetch-scheme-functions*)))))
 
 (add-to-fetch-scheme-functions)

--- a/local-init/https.lisp
+++ b/local-init/https.lisp
@@ -32,12 +32,13 @@
 (defun run-fetch (url file &rest args &key quietly &allow-other-keys)
   (declare (ignore args))
   (let ((url (https-of url)))
-    (with-logging (url file :quietly quietly)
-      (uiop:run-program (list *fetch-script*
-                              url
-                              (uiop:native-namestring
-                               (uiop:ensure-absolute-pathname file *default-pathname-defaults*)))
-                        :error-output :interactive))))
+    (uiop:run-program (list *fetch-script*
+                            url
+                            (uiop:native-namestring
+                             (uiop:ensure-absolute-pathname file *default-pathname-defaults*)))
+                      :output (and (not quietly)
+                                   :interactive)
+                      :error-output :interactive)))
 
 (defun which (cmd)
   (handler-case

--- a/local-init/https.lisp
+++ b/local-init/https.lisp
@@ -46,13 +46,18 @@
                'float)))))
 
 (defun add-to-fetch-scheme-functions ()
-  (let ((fn (cond
-              ((and (uiop:file-exists-p *fetch-script*)
-                    (uiop:file-exists-p
-                     (asdf:system-relative-pathname :qlot #P".qlot/setup.lisp")))
-               'run-fetch)
-              ((which "curl")
-               'curl-fetch))))
+  (let* ((preference (uiop:getenv "QLOT_FETCH"))
+         (fn (cond
+               ((and (or (null preference)
+                         (equal preference "dexador"))
+                     (and (uiop:file-exists-p *fetch-script*)
+                          (uiop:file-exists-p
+                           (asdf:system-relative-pathname :qlot #P".qlot/setup.lisp"))))
+                'run-fetch)
+               ((and (or (null preference)
+                         (equal preference "curl"))
+                     (which "curl"))
+                'curl-fetch))))
     (when fn
       (setf ql-http:*fetch-scheme-functions*
             (append `(("https" . ,fn)

--- a/local-init/https.lisp
+++ b/local-init/https.lisp
@@ -1,0 +1,43 @@
+(defpackage #:qlot/local-init/https
+  (:use #:cl))
+(in-package #:qlot/local-init/https)
+
+(defun https-of (url)
+  (if (and (stringp url)
+           (<= 7 (length url))
+           (search "http://" url :end2 7))
+      (format nil "https://~A" (subseq url 7))
+      url))
+
+(defun which (cmd)
+  (handler-case
+      (string-right-trim '(#\Newline)
+                         (with-output-to-string (s)
+                           (uiop:run-program `("which" ,cmd)
+                                             :output s)))
+    (uiop/run-program:subprocess-error ()
+      nil)))
+
+(defun curl-fetch (url file &rest args)
+  (declare (ignore args))
+  (let ((url (https-of url)))
+    (format t "~&; Fetching '~A'.~%" url)
+    (let ((now (get-internal-real-time)))
+      (uiop:run-program (list "curl" "-sSL" url "-o" (uiop:native-namestring file))
+                        :error-output :interactive)
+      (format t "~&; Done '~A' (~$KB) in ~A seconds.~%"
+              (file-namestring file)
+              (/ (ql-util:file-size file) 1024)
+              (coerce
+               (/ (- (get-internal-real-time) now)
+                  internal-time-units-per-second)
+               'float)))))
+
+(defun add-to-fetch-scheme-functions ()
+  (when (which "curl")
+    (setf ql-http:*fetch-scheme-functions*
+          (append '(("https" . curl-fetch)
+                    ("http" . curl-fetch))
+                  ql-http:*fetch-scheme-functions*))))
+
+(add-to-fetch-scheme-functions)

--- a/local-init/https.lisp
+++ b/local-init/https.lisp
@@ -63,16 +63,18 @@
                         :error-output :interactive))))
 
 (defun add-to-fetch-scheme-functions ()
-  (let ((fn (cond
-              ((and *fetch-script*
-                    (uiop:file-exists-p *fetch-script*)
-                    (uiop:file-exists-p
-                     (asdf:system-relative-pathname :qlot #P".qlot/setup.lisp")))
-               'run-fetch)
-              ((which "curl")
-               'curl-fetch)
-              ((which "wget")
-               'wget-fetch))))
+  (let* ((preference (uiop:getenv "QLOT_FETCH"))
+         (fn (cond
+               ((and (null preference)
+                     *fetch-script*
+                     (uiop:file-exists-p *fetch-script*)
+                     (uiop:file-exists-p
+                      (asdf:system-relative-pathname :qlot #P".qlot/setup.lisp")))
+                'run-fetch)
+               ((which "curl")
+                'curl-fetch)
+               ((which "wget")
+                'wget-fetch))))
     (when fn
       (setf ql-http:*fetch-scheme-functions*
             (append `(("https" . ,fn)

--- a/local-init/https.lisp
+++ b/local-init/https.lisp
@@ -2,6 +2,10 @@
   (:use #:cl))
 (in-package #:qlot/local-init/https)
 
+(defvar *fetch-script*
+  (uiop:native-namestring
+   (asdf:system-relative-pathname :qlot #P"scripts/fetch.sh")))
+
 (defun https-of (url)
   (if (and (stringp url)
            (<= 7 (length url))
@@ -9,35 +13,21 @@
       (format nil "https://~A" (subseq url 7))
       url))
 
-(defun which (cmd)
-  (handler-case
-      (string-right-trim '(#\Newline)
-                         (with-output-to-string (s)
-                           (uiop:run-program `("which" ,cmd)
-                                             :output s)))
-    (uiop/run-program:subprocess-error ()
-      nil)))
-
-(defun curl-fetch (url file &rest args)
-  (declare (ignore args))
-  (let ((url (https-of url)))
-    (format t "~&; Fetching '~A'.~%" url)
-    (let ((now (get-internal-real-time)))
-      (uiop:run-program (list "curl" "-sSL" url "-o" (uiop:native-namestring file))
-                        :error-output :interactive)
-      (format t "~&; Done '~A' (~$KB) in ~A seconds.~%"
-              (file-namestring file)
-              (/ (ql-util:file-size file) 1024)
-              (coerce
-               (/ (- (get-internal-real-time) now)
-                  internal-time-units-per-second)
-               'float)))))
+(defun run-fetch (url file)
+  (uiop:run-program (list *fetch-script*
+                          (https-of url)
+                          (uiop:native-namestring
+                           (uiop:ensure-absolute-pathname file *default-pathname-defaults*)))
+                    :output :interactive
+                    :error-output :interactive))
 
 (defun add-to-fetch-scheme-functions ()
-  (when (which "curl")
+  (when (and (uiop:file-exists-p *fetch-script*)
+             (uiop:file-exists-p
+              (asdf:system-relative-pathname :qlot #P".qlot/setup.lisp")))
     (setf ql-http:*fetch-scheme-functions*
-          (append '(("https" . curl-fetch)
-                    ("http" . curl-fetch))
+          (append '(("https" . run-fetch)
+                    ("http" . run-fetch))
                   ql-http:*fetch-scheme-functions*))))
 
 (add-to-fetch-scheme-functions)

--- a/scripts/fetch.sh
+++ b/scripts/fetch.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+QLOT_SOURCE_DIR=$(cd "$(dirname "$0")/../" 2>&1 && pwd -P)
+
+errmsg() { echo -e "\e[31mError: $1\e[0m" >&2; }
+if [ "$(which sbcl)" != "" ]; then
+  lisp="sbcl"
+elif [ "$(which ros)" != "" ]; then
+  lisp="ros without-roswell=t -L sbcl-bin run --"
+else
+  errmsg "sbcl is required by Qlot."
+  exit 1
+fi
+
+exec $lisp --noinform --no-sysinit --no-userinit --non-interactive \
+  --load $QLOT_SOURCE_DIR/.qlot/setup.lisp \
+  --eval "(asdf:load-asd #P\"$QLOT_SOURCE_DIR/qlot.asd\")" \
+  --eval '(ql:quickload :qlot/fetch :silent t)' \
+  --eval '(qlot/fetch::main)' -- "$@"

--- a/scripts/fetch.sh
+++ b/scripts/fetch.sh
@@ -3,10 +3,10 @@
 QLOT_SOURCE_DIR=$(cd "$(dirname "$0")/../" 2>&1 && pwd -P)
 
 errmsg() { echo -e "\e[31mError: $1\e[0m" >&2; }
-if [ "$(which sbcl)" != "" ]; then
-  lisp="sbcl"
-elif [ "$(which ros)" != "" ]; then
+if [ "$(which ros)" != "" ]; then
   lisp="ros without-roswell=t -L sbcl-bin run --"
+elif [ "$(which sbcl)" != "" ]; then
+  lisp="sbcl"
 else
   errmsg "sbcl is required by Qlot."
   exit 1

--- a/scripts/qlot-installer.sh
+++ b/scripts/qlot-installer.sh
@@ -41,12 +41,9 @@ qlot_version() {
     --eval '(require :asdf)' --eval "(asdf:load-asd \"$QLOT_SOURCE_DIR/qlot.asd\")" \
     --eval '(progn (princ (asdf:component-version (asdf:find-system :qlot))) (fresh-line))'
 }
-systems_directory() {
-  $lisp --noinform --no-sysinit --no-userinit --non-interactive \
-    --eval '(require :asdf)' --eval '(princ (uiop:native-namestring (uiop:xdg-data-home #P"common-lisp/systems/")))'
-}
 
 check_requirement "curl"
+check_requirement "tar"
 
 success 'Welcome to Qlot automatic installer!'
 echo ''
@@ -87,12 +84,6 @@ fi
 mkdir -p "$QLOT_BIN_DIR"
 printf '#!/bin/sh\nexec %s/scripts/run.sh "$@"\n' "$QLOT_SOURCE_DIR" > "$QLOT_BIN_DIR/qlot"
 chmod 755 "$QLOT_BIN_DIR/qlot"
-
-registry_dir=$(systems_directory)
-mkdir -p "$registry_dir"
-if [ ! -f "${registry_dir}qlot.asd" ]; then
-  ln -s "$QLOT_SOURCE_DIR/qlot.asd" "${registry_dir}qlot.asd"
-fi
 
 echo ''
 success "Qlot v$(qlot_version) has been successfully installed under '$QLOT_HOME'."

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-QLOT_SOURCE_DIR=$(cd "$(dirname "$0")/../" && pwd -P)
+QLOT_SOURCE_DIR=$(cd "$(dirname "$0")/../" 2>&1 && pwd -P)
 command=$1
 
 check_qlot_directory() {

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -14,8 +14,6 @@ else
   exit 1
 fi
 
-export QLOT_FETCH=curl
-
 if [ ! -f "$QLOT_SOURCE_DIR/.qlot/setup.lisp" ]; then
   $lisp --noinform --no-sysinit --no-userinit --non-interactive \
     --eval '(require :asdf)' \

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -14,6 +14,8 @@ else
   exit 1
 fi
 
+export QLOT_FETCH=curl
+
 if [ ! -f "$QLOT_SOURCE_DIR/.qlot/setup.lisp" ]; then
   $lisp --noinform --no-sysinit --no-userinit --non-interactive \
     --eval '(require :asdf)' \

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -30,3 +30,13 @@ $lisp --noinform --no-sysinit --no-userinit --non-interactive \
   --load $QLOT_SOURCE_DIR/.qlot/setup.lisp \
   --eval "(asdf:load-asd #P\"$QLOT_SOURCE_DIR/qlot.asd\")" \
   --eval '(ql:quickload (list :qlot :qlot/distify))'
+
+systems_directory() {
+  $lisp --noinform --no-sysinit --no-userinit --non-interactive \
+    --eval '(require :asdf)' --eval '(princ (uiop:native-namestring (uiop:xdg-data-home #P"common-lisp/systems/")))'
+}
+registry_dir=$(systems_directory)
+mkdir -p "$registry_dir"
+if [ ! -f "${registry_dir}qlot.asd" ]; then
+  ln -s "$QLOT_SOURCE_DIR/qlot.asd" "${registry_dir}qlot.asd"
+fi

--- a/utils/http.lisp
+++ b/utils/http.lisp
@@ -27,11 +27,9 @@
            (and basic-auth
                 (list :basic-auth basic-auth)))))
 
-(defun get (url &key want-stream basic-auth)
+(defun get (url &rest args)
   (with-retry ()
     (apply #'dex:get url
            :keep-alive nil
-           :want-stream want-stream
            :proxy *proxy*
-           (and basic-auth
-                (list :basic-auth basic-auth)))))
+           args)))


### PR DESCRIPTION
Qlot downloads files via HTTPS when running `qlot install`. However, when using a project-local Quicklisp without Qlot, the general ql-http is used and download files via HTTP.

This PR adds `local-init/https.lisp` to fetch archives and metadata files via HTTPS without loading Qlot in the main process. This also used to download dependencies of Qlot when running setup.