### PR TITLE
Parallel installation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,5 +39,11 @@ jobs:
         run: scripts/setup.sh
       - name: Run install.sh
         run: scripts/install.sh
+      - name: Run qlot install for Lem
+        run: |
+          PATH="~/.qlot/bin:~/.roswell/bin:$PATH"
+          git clone https://github.com/lem-project/lem
+          cd lem
+          qlot install
       - name: Run qlot-uninstaller.sh
         run: scripts/qlot-uninstaller.sh

--- a/local-init/qlot-10-https.lisp
+++ b/local-init/qlot-10-https.lisp
@@ -32,10 +32,11 @@
 (defun run-fetch (url file &rest args &key quietly &allow-other-keys)
   (declare (ignore args))
   (let ((url (https-of url)))
-    (uiop:run-program (list *fetch-script*
-                            url
-                            (uiop:native-namestring
-                             (uiop:ensure-absolute-pathname file *default-pathname-defaults*)))
+    (uiop:run-program (list* *fetch-script*
+                             url
+                             (uiop:native-namestring
+                              (uiop:ensure-absolute-pathname file *default-pathname-defaults*))
+                             (and quietly (list "--quiet")))
                       :output (and (not quietly)
                                    :interactive)
                       :error-output :interactive))

--- a/qlot.asd
+++ b/qlot.asd
@@ -22,3 +22,5 @@
 (defsystem "qlot/tests"
   :depends-on ("qlot-tests")
   :in-order-to ((test-op (test-op "qlot-tests"))))
+
+(register-system-packages "lparallel" '(:lparallel :lparallel.queue))

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -10,7 +10,7 @@ ansi() {
 }
 if ! [ -t 1 ]; then
   ansi() { :; }
-  export QLOT_NO_COLOR=1
+  export QLOT_NO_TERMINAL=1
 fi
 errmsg() { printf "%sError: %s%s\n" "$(ansi 31)" "$1" "$(ansi 0)"; }
 

--- a/src/check.lisp
+++ b/src/check.lisp
@@ -15,9 +15,10 @@
   (:import-from #:qlot/server
                 #:with-qlot-server)
   (:import-from #:qlot/logger
-                #:message
-                #:progress
-                #:clear-progress)
+                #:message)
+  (:import-from #:qlot/logger
+                #:whisper
+                #:clear-whisper)
   (:import-from #:qlot/utils
                 #:with-package-functions)
   (:import-from #:qlot/utils/ql
@@ -153,7 +154,7 @@
                (let ((dist (find-dist (source-dist-name source))))
                  (if dist
                      (progn
-                       (progress "Checking update of ~S..." (source-project-name source))
+                       (whisper "Checking update of ~S..." (source-project-name source))
                        (with-qlot-server (source :destination tmp-dir
                                                  :distinfo-only t
                                                  :silent t)
@@ -164,6 +165,6 @@
                                         (source-project-name source)
                                         (version dist)
                                         (source-version source)))
-                             (clear-progress))))
+                             (clear-whisper))))
                      (message "~S is not installed yet. Skipped."
                               (source-project-name source))))))))))))

--- a/src/cli.lisp
+++ b/src/cli.lisp
@@ -3,7 +3,7 @@
   (:import-from #:qlot/logger
                 #:message
                 #:*logger-message-stream*
-                #:clear-progress)
+                #:clear-whisper)
   (:import-from #:qlot/errors
                 #:missing-projects
                 #:unnecessary-projects
@@ -690,7 +690,7 @@ OPTIONS:
   (uiop:quit -1))
 
 (defun qlot-command (&optional $1 &rest argv)
-  (let ((*enable-color* (null (uiop:getenvp "QLOT_NO_COLOR"))))
+  (let ((*enable-color* (null (uiop:getenvp "QLOT_NO_TERMINAL"))))
     (handler-bind ((qlot/errors:qlot-warning
                      (lambda (c)
                        (warn-message "WARNING: ~A" c)
@@ -741,7 +741,7 @@ OPTIONS:
                    (otherwise))
                  (error 'qlot/errors:command-not-found :command $1)))
         #+sbcl (sb-sys:interactive-interrupt ()
-                 (clear-progress)
+                 (clear-whisper)
                  (uiop:quit -1))
         (qlot/errors:command-not-found (e)
           (error-message (princ-to-string e))

--- a/src/cli.lisp
+++ b/src/cli.lisp
@@ -3,6 +3,7 @@
   (:import-from #:qlot/logger
                 #:message
                 #:*logger-message-stream*
+                #:*terminal*
                 #:clear-whisper)
   (:import-from #:qlot/errors
                 #:missing-projects
@@ -690,7 +691,10 @@ OPTIONS:
   (uiop:quit -1))
 
 (defun qlot-command (&optional $1 &rest argv)
-  (let ((*enable-color* (null (uiop:getenvp "QLOT_NO_TERMINAL"))))
+  (let* ((no-terminal-env (uiop:getenvp "QLOT_NO_TERMINAL"))
+         (*terminal* (or (not no-terminal-env)
+                         (uiop:getenvp "CI")))
+         (*enable-color* *terminal*))
     (handler-bind ((qlot/errors:qlot-warning
                      (lambda (c)
                        (warn-message "WARNING: ~A" c)

--- a/src/cli.lisp
+++ b/src/cli.lisp
@@ -246,12 +246,19 @@ Run 'qlot COMMAND --help' for more information on a subcommand.
 
 (defun qlot-command-install (argv)
   (let ((install-deps t)
-        (cache nil))
+        (cache nil)
+        concurrency)
     (do-options (option argv)
       ("--no-deps"
        (setf install-deps nil))
       (("--cache" cache-dir)
        (setf cache cache-dir))
+      (("--jobs" jobs)
+       (unless (every (lambda (char)
+                        (char<= #\0 char #\9))
+                      jobs)
+         (qlot/errors:ros-command-error "Invalid option value for --jobs: ~A" jobs))
+       (setf concurrency (parse-integer jobs)))
       ("--debug"
        (qlot-option-debug))
       ("--help"
@@ -266,6 +273,8 @@ OPTIONS:
         Don't install dependencies of all systems from the current directory.
     --cache [directory]
         Keep intermediate files for fast reinstallation.
+    --jobs [concurrency]
+        The number of threads to install simultaneously. (Default: 4)
     --debug
         A flag to enable debug logging.
 ")
@@ -282,7 +291,8 @@ OPTIONS:
                       :cache-directory (and cache
                                             (uiop:ensure-absolute-pathname
                                              (uiop:ensure-directory-pathname cache)
-                                             *default-pathname-defaults*)))))
+                                             *default-pathname-defaults*))
+                      :concurrency concurrency)))
 
 (defun qlot-command-update (argv)
   (let ((install-deps t)

--- a/src/cli.lisp
+++ b/src/cli.lisp
@@ -341,8 +341,7 @@ OPTIONS:
                       :cache-directory (and cache
                                             (uiop:ensure-absolute-pathname
                                              (uiop:ensure-directory-pathname cache)
-                                             *default-pathname-defaults*))
-                      :quiet (not (null projects)))))
+                                             *default-pathname-defaults*)))))
 
 (defun qlot-command-init (argv)
   (flet ((print-init-usage ()
@@ -541,8 +540,7 @@ OPTIONS:
                              (declare (ignore e))
                              (uiop:copy-file qlfile.bak qlfile))))
             (uiop:symbol-call '#:qlot/install '#:install-project *default-pathname-defaults*
-                              :install-deps nil
-                              :quiet t)))))))
+                              :install-deps nil)))))))
 
 (defun qlot-command-remove (argv)
   (flet ((print-remove-usage ()
@@ -592,8 +590,7 @@ SYNOPSIS:
                                  (uiop:copy-file qlfile.bak qlfile))))
                 (uiop:symbol-call '#:qlot/install '#:install-project
                                   *default-pathname-defaults*
-                                  :install-deps nil
-                                  :quiet t)))))))))
+                                  :install-deps nil)))))))))
 
 (defun qlot-command-check (argv)
   (flet ((print-check-usage ()

--- a/src/distify.lisp
+++ b/src/distify.lisp
@@ -12,7 +12,7 @@
                 #:source-http
                 #:source-dist
                 #:source-dist-project)
-  (:import-from #:qlot/logger
+  (:import-from #:qlot/progress
                 #:progress)
   (:import-from #:qlot/errors
                 #:qlot-error)

--- a/src/distify/dist.lisp
+++ b/src/distify/dist.lisp
@@ -5,7 +5,7 @@
                 #:source-distribution
                 #:source-distinfo-url
                 #:source-project-name)
-  (:import-from #:qlot/logger
+  (:import-from #:qlot/progress
                 #:progress)
   (:import-from #:qlot/utils/distify
                 #:get-distinfo-url)

--- a/src/distify/git.lisp
+++ b/src/distify/git.lisp
@@ -15,7 +15,7 @@
                 #:source-git-identifier)
   (:import-from #:qlot/source/ql
                 #:source-ql-upstream)
-  (:import-from #:qlot/logger
+  (:import-from #:qlot/progress
                 #:progress)
   (:import-from #:qlot/utils/distify
                 #:releases.txt

--- a/src/distify/github.lisp
+++ b/src/distify/github.lisp
@@ -10,7 +10,7 @@
                 #:source-github-tag
                 #:source-github-identifier
                 #:source-github-url)
-  (:import-from #:qlot/logger
+  (:import-from #:qlot/progress
                 #:progress)
   (:import-from #:qlot/utils/distify
                 #:releases.txt

--- a/src/distify/http.lisp
+++ b/src/distify/http.lisp
@@ -6,7 +6,7 @@
                 #:source-http-archive-md5
                 #:source-version
                 #:source-version-prefix)
-  (:import-from #:qlot/logger
+  (:import-from #:qlot/progress
                 #:progress)
   (:import-from #:qlot/utils/distify
                 #:releases.txt

--- a/src/distify/ql.lisp
+++ b/src/distify/ql.lisp
@@ -6,7 +6,7 @@
                 #:source-version-prefix
                 #:source-distinfo-url
                 #:source-distribution)
-  (:import-from #:qlot/logger
+  (:import-from #:qlot/progress
                 #:progress)
   (:import-from #:qlot/utils/ql
                 #:parse-distinfo-stream

--- a/src/install.lisp
+++ b/src/install.lisp
@@ -257,9 +257,17 @@ exec /bin/sh \"$CURRENT/../~A\" \"$@\"
           (error 'duplicate-project :name dup)))
       (unwind-protect
            (let* ((sources-to-install
-                   (remove-if (lambda (source)
-                                (typep source 'source-local))
-                              sources))
+                    (with-quicklisp-home qlhome
+                      (with-package-functions #:ql-dist (find-dist version)
+                        (remove-if (lambda (source)
+                                     (let ((dist (find-dist (source-dist-name source))))
+                                       (and dist
+                                            (slot-boundp source 'qlot/source/base::version)
+                                            (equal (version dist)
+                                                   (source-version source)))))
+                                   (remove-if (lambda (source)
+                                                (typep source 'source-local))
+                                              sources)))))
                  (bt2:*default-special-bindings* (append `((*enable-color* . ,*enable-color*)
                                                            (*terminal* . ,*terminal*)
                                                            (*enable-whisper* . nil)

--- a/src/install.lisp
+++ b/src/install.lisp
@@ -121,7 +121,8 @@
 (defun update-qlfile (qlfile &key quicklisp-home
                                   projects
                                   (install-deps t)
-                                  cache-directory)
+                                  cache-directory
+                                  concurrency)
   (unless (uiop:file-exists-p qlfile)
     (error 'qlfile-not-found :path qlfile))
 
@@ -139,7 +140,8 @@
       (apply-qlfile-to-qlhome qlfile quicklisp-home
                               :ignore-lock t
                               :projects projects
-                              :cache-directory cache-directory)
+                              :cache-directory cache-directory
+                              :concurrency concurrency)
 
       ;; Install project dependencies
       (when install-deps
@@ -383,21 +385,25 @@ exec /bin/sh \"$CURRENT/../~A\" \"$@\"
 
 (defun update-project (object &key projects
                                    (install-deps t)
-                                   cache-directory)
+                                   cache-directory
+                                   concurrency)
   (etypecase object
     ((or symbol string)
      (update-project (asdf:find-system object)
                      :projects projects
                      :install-deps install-deps
-                     :cache-directory cache-directory))
+                     :cache-directory cache-directory
+                     :concurrency concurrency))
     (asdf:system
       (update-qlfile (asdf:system-relative-pathname object *default-qlfile*)
                      :quicklisp-home (asdf:system-relative-pathname object *qlot-directory*)
                      :projects projects
                      :install-deps install-deps
-                     :cache-directory cache-directory))
+                     :cache-directory cache-directory
+                     :concurrency concurrency))
     (pathname
       (update-qlfile (ensure-qlfile-pathname object)
                      :projects projects
                      :install-deps install-deps
-                     :cache-directory cache-directory))))
+                     :cache-directory cache-directory
+                     :concurrency concurrency))))

--- a/src/install.lisp
+++ b/src/install.lisp
@@ -221,14 +221,14 @@ exec /bin/sh \"$CURRENT/../~A\" \"$@\"
                 (update-in-place dist new-dist))
               (setf (source-version source) (version new-dist))
               (install-all-releases source)
-              (message "=> Updated dist ~S to version ~S."
-                       (source-project-name source)
-                       (source-version source)))
+              (progress :done "Updated dist ~S to version ~S."
+                        (source-project-name source)
+                        (source-version source)))
             (progn
               (setf (source-version source) (version (find-dist (source-dist-name source))))
-              (message "=> No update on dist ~S version ~S"
-                       (source-dist-name source)
-                       (source-version source))))
+              (progress :done "No update on dist ~S version ~S"
+                        (source-dist-name source)
+                        (source-version source))))
         new-dist))))
 
 (defun progress-indicator (current max &key label)

--- a/src/install.lisp
+++ b/src/install.lisp
@@ -74,6 +74,12 @@
            #:update-project))
 (in-package #:qlot/install)
 
+(defmacro without-linewrap (() &body body)
+  `(progn
+     (format t "~C[?7l" #\Esc)
+     (unwind-protect (progn ,@body)
+       (format t "~C[?7h" #\Esc))))
+
 (defun install-dependencies (project-root qlhome)
   (with-quicklisp-home qlhome
     (let ((all-dependencies (with-package-functions #:ql-dist (find-system)
@@ -107,14 +113,15 @@
     (unless (find-package '#:ql)
       (load (merge-pathnames #P"setup.lisp" quicklisp-home)))
 
-    (with-secure-installer ()
-      (apply-qlfile-to-qlhome qlfile quicklisp-home
-                              :cache-directory cache-directory
-                              :concurrency concurrency)
+    (without-linewrap ()
+      (with-secure-installer ()
+        (apply-qlfile-to-qlhome qlfile quicklisp-home
+                                :cache-directory cache-directory
+                                :concurrency concurrency)
 
-      ;; Install project dependencies
-      (when install-deps
-        (install-dependencies project-root quicklisp-home)))
+        ;; Install project dependencies
+        (when install-deps
+          (install-dependencies project-root quicklisp-home))))
 
     (message "Successfully installed.")))
 
@@ -136,16 +143,17 @@
     (unless (find-package '#:ql)
       (load (merge-pathnames #P"setup.lisp" quicklisp-home)))
 
-    (with-secure-installer ()
-      (apply-qlfile-to-qlhome qlfile quicklisp-home
-                              :ignore-lock t
-                              :projects projects
-                              :cache-directory cache-directory
-                              :concurrency concurrency)
+    (without-linewrap ()
+      (with-secure-installer ()
+        (apply-qlfile-to-qlhome qlfile quicklisp-home
+                                :ignore-lock t
+                                :projects projects
+                                :cache-directory cache-directory
+                                :concurrency concurrency)
 
-      ;; Install project dependencies
-      (when install-deps
-        (install-dependencies project-root quicklisp-home)))
+        ;; Install project dependencies
+        (when install-deps
+          (install-dependencies project-root quicklisp-home))))
 
     (message "Successfully installed.")))
 

--- a/src/install.lisp
+++ b/src/install.lisp
@@ -76,9 +76,11 @@
 
 (defmacro without-linewrap (() &body body)
   `(progn
-     (format t "~C[?7l" #\Esc)
+     (when *terminal*
+       (format t "~C[?7l" #\Esc))
      (unwind-protect (progn ,@body)
-       (format t "~C[?7h" #\Esc))))
+       (when *terminal*
+         (format t "~C[?7h" #\Esc)))))
 
 (defun install-dependencies (project-root qlhome)
   (with-quicklisp-home qlhome

--- a/src/install.lisp
+++ b/src/install.lisp
@@ -23,6 +23,7 @@
                 #:distify)
   (:import-from #:qlot/logger
                 #:*enable-whisper*
+                #:*terminal*
                 #:message
                 #:debug-log)
   (:import-from #:qlot/secure-downloader
@@ -262,6 +263,7 @@ exec /bin/sh \"$CURRENT/../~A\" \"$@\"
                                 (typep source 'source-local))
                               sources))
                  (bt2:*default-special-bindings* (append `((*enable-color* . ,*enable-color*)
+                                                           (*terminal* . ,*terminal*)
                                                            (*enable-whisper* . nil)
                                                            (,(uiop:intern* '#:*fetch-scheme-functions* '#:ql-http) . ',(symbol-value (uiop:intern* '#:*fetch-scheme-functions* '#:ql-http))))
                                                          bt2:*default-special-bindings*))

--- a/src/logger.lisp
+++ b/src/logger.lisp
@@ -26,13 +26,10 @@
 
 (defvar *terminal* nil)
 
-(defparameter *padding* "- ")
-
 (defun whisper (format-control &rest format-arguments)
   (when *enable-whisper*
-    (let* ((out *logger-message-stream*)
-           (text (apply #'format nil format-control format-arguments))
-           (text (concatenate 'string *padding* text)))
+    (let ((out *logger-message-stream*)
+          (text (apply #'format nil format-control format-arguments)))
       (when *terminal*
         (format out "~C[2K" #\Esc))
       (write-char #\Return out)

--- a/src/logger.lisp
+++ b/src/logger.lisp
@@ -30,9 +30,11 @@
   (when *enable-whisper*
     (let ((out *logger-message-stream*)
           (text (apply #'format nil format-control format-arguments)))
-      (when *terminal*
-        (format out "~C[2K" #\Esc))
-      (write-char #\Return out)
+      (if *terminal*
+          (progn
+            (format out "~C[2K" #\Esc)
+            (write-char #\Return out))
+          (fresh-line out))
       (write-string (color-text :gray text) out)
       (force-output out)
       (setf *previous-progress* text))))

--- a/src/logger.lisp
+++ b/src/logger.lisp
@@ -6,6 +6,7 @@
            #:*logger-debug-stream*
            #:*debug*
            #:*enable-whisper*
+           #:*terminal*
            #:whisper
            #:clear-whisper
            #:message
@@ -23,17 +24,16 @@
 
 (defvar *previous-progress* "")
 
-(defparameter *padding* "- ")
+(defvar *terminal* nil)
 
-(defun terminal-p ()
-  (not (uiop:getenvp "QLOT_NO_TERMINAL")))
+(defparameter *padding* "- ")
 
 (defun whisper (format-control &rest format-arguments)
   (when *enable-whisper*
     (let* ((out *logger-message-stream*)
            (text (apply #'format nil format-control format-arguments))
            (text (concatenate 'string *padding* text)))
-      (when (terminal-p)
+      (when *terminal*
         (format out "~C[2K" #\Esc))
       (write-char #\Return out)
       (write-string (color-text :gray text) out)
@@ -43,7 +43,7 @@
 (defun clear-whisper ()
   (when (= 0 (length *previous-progress*))
     (return-from clear-whisper))
-  (when (terminal-p)
+  (when *terminal*
     (format *logger-message-stream* "~C[2K" #\Esc))
   (write-char #\Return *logger-message-stream*)
   (force-output *logger-message-stream*)

--- a/src/progress.lisp
+++ b/src/progress.lisp
@@ -81,7 +81,8 @@
 
 (defun clear-line ()
   (when *terminal*
-    (format *progress-output* "~C[2K" #\Esc)))
+    (format *progress-output* "~C[2K" #\Esc))
+  (write-char #\Return *progress-output*))
 
 (defmacro with-excursion ((stream) &body body)
   `(let ((*progress-output* ,stream))

--- a/src/progress.lisp
+++ b/src/progress.lisp
@@ -1,5 +1,7 @@
 (defpackage #:qlot/progress
   (:use #:cl)
+  (:import-from #:qlot/logger
+                #:*terminal*)
   (:import-from #:qlot/color
                 #:color-text)
   (:import-from #:bordeaux-threads)
@@ -73,23 +75,20 @@
 
 (defvar *progress-output* nil)
 
-(defun terminal-p ()
-  (not (uiop:getenvp "QLOT_NO_TERMINAL")))
-
 (defun move-up (n)
-  (when (terminal-p)
+  (when *terminal*
     (format *progress-output* "~C[~DA" #\Esc n)))
 
 (defun clear-line ()
-  (when (terminal-p)
+  (when *terminal*
     (format *progress-output* "~C[2K" #\Esc)))
 
 (defmacro with-excursion ((stream) &body body)
   `(let ((*progress-output* ,stream))
-     (when (terminal-p)
+     (when *terminal*
        (format *progress-output* "~C[s" #\Esc))
      (prog1 (progn ,@body)
-       (when (terminal-p)
+       (when *terminal*
          (format *progress-output* "~C[u" #\Esc))
        (force-output *progress-output*))))
 

--- a/src/progress.lisp
+++ b/src/progress.lisp
@@ -156,4 +156,4 @@
                              (funcall (or job-header-fn #'princ-to-string) job))))
              (funcall worker-fn job)))
          jobs)
-      (bt2:destroy-thread progress-thread))))
+      (ignore-errors (bt2:destroy-thread progress-thread)))))

--- a/src/progress.lisp
+++ b/src/progress.lisp
@@ -81,9 +81,7 @@
 
 (defun clear-line ()
   (if *terminal*
-      (progn
-        (write-char #\Return *progress-output*)
-        (format *progress-output* "~C[0K" #\Esc))
+      (format *progress-output* "~C[2K" #\Esc)
       (fresh-line *progress-output*)))
 
 (defmacro with-excursion ((stream) &body body)

--- a/src/progress.lisp
+++ b/src/progress.lisp
@@ -1,0 +1,88 @@
+(defpackage #:qlot/progress
+  (:use #:cl)
+  (:import-from #:bordeaux-threads)
+  (:export #:make-progress
+           #:make-line
+           #:print-progress
+           #:refresh-progress-line
+           #:add-line))
+(in-package #:qlot/progress)
+
+(defgeneric print-progress (object stream))
+
+(defstruct (progress-line
+             (:constructor make-line (header &optional body)))
+  (header "" :type string)
+  (body "" :type string))
+
+(defmethod print-progress ((object progress-line) stream)
+  (format stream "~A~A~%"
+          (progress-line-header object)
+          (progress-line-body object)))
+
+(defstruct (progress-manager (:constructor %make-progress-manager))
+  (lines nil :type list)
+  (printed-p nil :type boolean)
+  (stream nil :type (or stream null))
+  (lock (bt2:make-lock :name "progress-manager-lock")
+        :type bt2:lock))
+
+(defun make-progress (line-or-lines)
+  (let ((lines (if (listp line-or-lines)
+                   line-or-lines
+                   (list line-or-lines))))
+    (assert (every (lambda (line) (typep line 'progress-line)) lines))
+    (%make-progress-manager :lines lines)))
+
+(defmacro with-manager-lock ((manager) &body body)
+  `(bt2:with-lock-held ((progress-manager-lock ,manager))
+     ,@body))
+
+(defmethod print-progress ((manager progress-manager) stream)
+  (assert (not (progress-manager-printed-p manager)))
+  (with-manager-lock (manager)
+    (loop for line in (progress-manager-lines manager)
+          do (print-progress line stream))
+    (setf (progress-manager-stream manager) stream
+          (progress-manager-printed-p manager) t))
+  (values))
+
+(defvar *progress-output* nil)
+
+(defun move-up (n)
+  (format *progress-output* "~C[~DA" #\Esc n))
+
+(defun clear-line ()
+  (format *progress-output* "~C[2K" #\Esc))
+
+(defmacro with-excursion ((stream) &body body)
+  `(let ((*progress-output* ,stream))
+     (format *progress-output* "~C[s" #\Esc)
+     (prog1 (progn ,@body)
+       (format *progress-output* "~C[u" #\Esc)
+       (force-output *progress-output*))))
+
+(defun refresh-progress-line (manager line)
+  (check-type manager progress-manager)
+  (check-type line progress-line)
+  (assert (progress-manager-printed-p manager))
+  (assert (find line (progress-manager-lines manager) :test 'eq))
+  (with-manager-lock (manager)
+    (let* ((lines (progress-manager-lines manager))
+           (pos (position line lines :test 'eq))
+           (len (length lines)))
+      (with-excursion ((progress-manager-stream manager))
+        (move-up (- len pos))
+        (clear-line)
+        (print-progress line (progress-manager-stream manager)))))
+  (values))
+
+(defun add-line (manager header &key (initial-body ""))
+  (check-type manager progress-manager)
+  (let ((new-line (make-line header initial-body)))
+    (with-manager-lock (manager)
+      (when (progress-manager-printed-p manager)
+        (print-progress new-line (progress-manager-stream manager)))
+      (setf (cdr (last (progress-manager-lines manager)))
+            (list new-line)))
+    new-line))

--- a/src/progress.lisp
+++ b/src/progress.lisp
@@ -80,9 +80,11 @@
     (format *progress-output* "~C[~DA" #\Esc n)))
 
 (defun clear-line ()
-  (when *terminal*
-    (format *progress-output* "~C[2K" #\Esc))
-  (write-char #\Return *progress-output*))
+  (if *terminal*
+      (progn
+        (format *progress-output* "~C[2K" #\Esc)
+        (write-char #\Return *progress-output*))
+      (fresh-line *progress-output*)))
 
 (defmacro with-excursion ((stream) &body body)
   `(let ((*progress-output* ,stream))

--- a/src/progress.lisp
+++ b/src/progress.lisp
@@ -1,79 +1,110 @@
 (defpackage #:qlot/progress
   (:use #:cl)
+  (:import-from #:qlot/color
+                #:color-text)
   (:import-from #:bordeaux-threads)
+  (:import-from #:chanl
+                #:unbounded-channel
+                #:send
+                #:recv)
+  (:import-from #:lparallel
+                #:pmapc
+                #:*kernel*
+                #:make-kernel)
   (:export #:make-progress
            #:make-line
            #:print-progress
            #:refresh-progress-line
-           #:add-line))
+           #:add-line
+           #:progress
+           #:run-in-parallel))
 (in-package #:qlot/progress)
 
 (defgeneric print-progress (object stream))
 
 (defstruct (progress-line
              (:constructor make-line (header &optional body)))
+  (type :in-progress :type (or null (member :in-progress :done :aborted)))
   (header "" :type string)
   (body "" :type string))
 
+(defun progress-symbol (type)
+  (ecase type
+    (:in-progress
+     (color-text :yellow
+                 (string (code-char 9679))))
+    (:done
+     (color-text :green
+                 (string (code-char 10003))))
+    (:aborted
+     (color-text :red
+                 (string (code-char 10799))))
+    ('nil nil)))
+
 (defmethod print-progress ((object progress-line) stream)
-  (format stream "~A~A~%"
+  (format stream "~@[~A ~]~A  ~A~%"
+          (progress-symbol (progress-line-type object))
           (progress-line-header object)
-          (progress-line-body object)))
+          (color-text :gray (progress-line-body object))))
 
 (defstruct (progress-manager (:constructor %make-progress-manager))
   (lines nil :type list)
-  (printed-p nil :type boolean)
   (stream nil :type (or stream null))
   (lock (bt2:make-lock :name "progress-manager-lock")
         :type bt2:lock))
 
-(defun make-progress (line-or-lines)
+(defun make-progress (line-or-lines &key (stream *standard-output*))
   (let ((lines (if (listp line-or-lines)
                    line-or-lines
                    (list line-or-lines))))
     (assert (every (lambda (line) (typep line 'progress-line)) lines))
-    (%make-progress-manager :lines lines)))
+    (%make-progress-manager :lines lines
+                            :stream stream)))
 
 (defmacro with-manager-lock ((manager) &body body)
   `(bt2:with-lock-held ((progress-manager-lock ,manager))
      ,@body))
 
 (defmethod print-progress ((manager progress-manager) stream)
-  (assert (not (progress-manager-printed-p manager)))
   (with-manager-lock (manager)
     (loop for line in (progress-manager-lines manager)
-          do (print-progress line stream))
-    (setf (progress-manager-stream manager) stream
-          (progress-manager-printed-p manager) t))
+          do (print-progress line stream)))
   (values))
 
 (defvar *progress-output* nil)
 
+(defun terminal-p ()
+  (not (uiop:getenvp "QLOT_NO_TERMINAL")))
+
 (defun move-up (n)
-  (format *progress-output* "~C[~DA" #\Esc n))
+  (when (terminal-p)
+    (format *progress-output* "~C[~DA" #\Esc n)))
 
 (defun clear-line ()
-  (format *progress-output* "~C[2K" #\Esc))
+  (when (terminal-p)
+    (format *progress-output* "~C[2K" #\Esc)))
 
 (defmacro with-excursion ((stream) &body body)
   `(let ((*progress-output* ,stream))
-     (format *progress-output* "~C[s" #\Esc)
+     (when (terminal-p)
+       (format *progress-output* "~C[s" #\Esc))
      (prog1 (progn ,@body)
-       (format *progress-output* "~C[u" #\Esc)
+       (when (terminal-p)
+         (format *progress-output* "~C[u" #\Esc))
        (force-output *progress-output*))))
 
 (defun refresh-progress-line (manager line)
   (check-type manager progress-manager)
   (check-type line progress-line)
-  (assert (progress-manager-printed-p manager))
   (assert (find line (progress-manager-lines manager) :test 'eq))
   (with-manager-lock (manager)
     (let* ((lines (progress-manager-lines manager))
            (pos (position line lines :test 'eq))
            (len (length lines)))
       (with-excursion ((progress-manager-stream manager))
-        (move-up (- len pos))
-        (clear-line)
+        (when pos
+          (move-up (- len pos))
+          (clear-line))
         (print-progress line (progress-manager-stream manager)))))
   (values))
 
@@ -81,8 +112,49 @@
   (check-type manager progress-manager)
   (let ((new-line (make-line header initial-body)))
     (with-manager-lock (manager)
-      (when (progress-manager-printed-p manager)
-        (print-progress new-line (progress-manager-stream manager)))
-      (setf (cdr (last (progress-manager-lines manager)))
-            (list new-line)))
+      (print-progress new-line (progress-manager-stream manager))
+      (if (progress-manager-lines manager)
+          (setf (cdr (last (progress-manager-lines manager)))
+                (list new-line))
+          (setf (progress-manager-lines manager)
+                (list new-line))))
     new-line))
+
+(defvar *mailbox*)
+(defvar *progress-line*)
+
+(defun progress (type &optional control &rest args)
+  (when (boundp '*progress-line*)
+    (unless (keywordp type)
+      (push control args)
+      (psetf control type
+             type nil))
+    (when type
+      (setf (progress-line-type *progress-line*) type))
+    (let ((text (apply #'format nil control args)))
+      (setf (progress-line-body *progress-line*) text)
+      (send *mailbox* *progress-line*)
+      text)))
+
+(defun run-in-parallel (worker-fn jobs &key (concurrency 1) job-header-fn)
+  (let* ((manager (make-progress nil))
+         (*mailbox* (make-instance 'unbounded-channel))
+         (bt2:*default-special-bindings* (cons `(*mailbox* . ,*mailbox*)
+                                               bt2:*default-special-bindings*))
+         (*kernel* (make-kernel concurrency
+                                :bindings bt2:*default-special-bindings*))
+         (progress-thread
+           (bt2:make-thread
+            (lambda ()
+              (loop for line = (recv *mailbox*)
+                    do (refresh-progress-line manager line)))
+            :name "qlot progress manager")))
+    (unwind-protect
+        (pmapc
+         (lambda (job)
+           (let ((*progress-line*
+                   (add-line manager
+                             (funcall (or job-header-fn #'princ-to-string) job))))
+             (funcall worker-fn job)))
+         jobs)
+      (bt2:destroy-thread progress-thread))))

--- a/src/progress.lisp
+++ b/src/progress.lisp
@@ -82,8 +82,8 @@
 (defun clear-line ()
   (if *terminal*
       (progn
-        (format *progress-output* "~C[2K" #\Esc)
-        (write-char #\Return *progress-output*))
+        (write-char #\Return *progress-output*)
+        (format *progress-output* "~C[0K" #\Esc))
       (fresh-line *progress-output*)))
 
 (defmacro with-excursion ((stream) &body body)

--- a/src/secure-downloader.lisp
+++ b/src/secure-downloader.lisp
@@ -4,18 +4,20 @@
   (:import-from #:qlot/proxy
                 #:*proxy*)
   (:import-from #:qlot/logger
-                #:progress)
+                #:whisper)
   (:import-from #:qlot/utils
                 #:https-of)
   (:export #:with-secure-installer))
 (in-package #:qlot/secure-downloader)
 
-(defun https-fetch (url file &rest args)
+(defun https-fetch (url file &rest args &key quiet &allow-other-keys)
   (declare (ignore args))
   (let ((url (https-of url)))
-    (progress "Downloading ~S." url)
-    (qlot/http:fetch url file)
-    (progress "Downloaded ~S." url)))
+    (unless quiet
+      (whisper "Downloading ~S." url))
+    (multiple-value-prog1 (qlot/http:fetch url file)
+      (unless quiet
+        (whisper "Downloaded ~S." url)))))
 
 (defmacro with-secure-installer (() &body body)
   `(progv (list (intern #.(string '#:*fetch-scheme-functions*) '#:ql-http)

--- a/src/server.lisp
+++ b/src/server.lisp
@@ -3,7 +3,7 @@
   (:import-from #:qlot/distify
                 #:distify)
   (:import-from #:qlot/logger
-                #:*enable-progress*)
+                #:*enable-whisper*)
   (:import-from #:qlot/utils/tmp
                 #:with-tmp-directory)
   (:export #:with-qlot-server))
@@ -41,7 +41,7 @@
        (,@(if destination
               `(let ((,g-destination ,destination)))
               `(with-tmp-directory (,g-destination)))
-        (let ((*enable-progress* (not ,silent)))
+        (let ((*enable-whisper* (not ,silent)))
           (distify ,g-source ,g-destination :distinfo-only ,distinfo-only))
         (progv (list ,fetch-scheme-functions '*handler*)
             (list (cons '("qlot" . qlot-fetch)

--- a/src/utils/dependencies.lisp
+++ b/src/utils/dependencies.lisp
@@ -5,6 +5,8 @@
   (:import-from #:qlot/utils/shell
                 #:run-lisp
                 #:*qlot-source-directory*)
+  (:import-from #:qlot/logger
+                #:*terminal*)
   (:import-from #:qlot/color
                 #:*enable-color*)
   (:export #:project-dependencies-in-child-process))
@@ -14,6 +16,7 @@
   (uiop:with-temporary-file (:pathname tmp)
     (run-lisp `((load ,(merge-pathnames #P"setup.lisp" quicklisp-home))
                 (setf *enable-color* ,*enable-color*)
+                (setf *terminal* ,*terminal*)
                 (with-open-file (cl-user::out ,tmp
                                               :direction :output
                                               :if-exists :supersede)

--- a/src/utils/project.lisp
+++ b/src/utils/project.lisp
@@ -12,7 +12,8 @@
                 #:split-with)
   (:import-from #:qlot/logger
                 #:*debug*
-                #:progress
+                #:whisper
+                #:message
                 #:debug-log)
   (:import-from #:qlot/errors
                 #:qlot-directory-not-found
@@ -97,7 +98,7 @@
                   (funcall test system-name))
           (unless (find system-file loaded-asd-files :test 'equal)
             (push system-file loaded-asd-files)
-            (progress "Loading '~A'..." system-file)
+            (whisper "Loading '~A'..." system-file)
             (incf file-counts)
             (let ((errout *error-output*))
               (handler-bind ((error
@@ -142,7 +143,7 @@
             (debug-log "'~A' requires ~S" system-name dependencies)
             (setf all-dependencies
                   (nconc all-dependencies dependencies)))))
-      (progress "Loaded ~A system files." file-counts)
+      (message "Loaded ~A system files." file-counts)
       (with-package-functions #:ql-dist (required-systems name)
         (let ((already-seen (make-hash-table :test 'equal)))
           (labels ((find-system-with-fallback (system-name)


### PR DESCRIPTION
Run libraries' dist installation in parallel while in `qlot install` or `qlot update`.

The number of threads can be specified with `--jobs` option. (Default: 4)