### PR TITLE
Ignore ".direnv" to look for ASD files in a project.

### DIFF
--- a/local-init/qlot-99-setup.lisp
+++ b/local-init/qlot-99-setup.lisp
@@ -44,7 +44,7 @@
          (cache (gethash key *project-system-cache*)))
     (and cache
          (not (cache-stale-p directory cache))
-         cache)))
+         (system-cache-system-files cache))))
 
 (defun put-cache (directory system-files)
   (setf (gethash (cache-key directory) *project-system-cache*)
@@ -58,13 +58,13 @@
        (let ((dirname (car (last (pathname-directory dir)))))
          (and (stringp dirname)
               (not (equal dirname ""))
-              (not (char= (aref dirname 0) #\.)))))
+              (not (char= (aref dirname 0) #\.))
+              (not (find dirname asdf/source-registry:*default-source-registry-exclusions*
+                         :test 'equal)))))
      t
      (lambda (dir)
-       (let* ((cache (find-cache dir))
-              (system-files
-                (if cache
-                    (system-cache-system-files cache)
+       (let* ((system-files
+                (or (find-cache dir)
                     (let ((asd-files
                             (uiop:directory-files dir "*.asd")))
                       (put-cache dir asd-files)

--- a/local-init/qlot-99-setup.lisp
+++ b/local-init/qlot-99-setup.lisp
@@ -20,6 +20,8 @@
                        (getf (uiop:read-file-form config-file) :qlot-source-directory))))
            `(:source-registry :ignore-inherited-configuration
              (:also-exclude ".qlot")
+             (:also-exclude ".bundle-libs")
+             (:also-exclude ".direnv")
              ,@(and qlot-source-directory
                     `((:directory ,qlot-source-directory)))
              (:tree ,project-root)))))))

--- a/src/utils/qlot.lisp
+++ b/src/utils/qlot.lisp
@@ -13,6 +13,9 @@
            #:dump-qlfile-lock))
 (in-package #:qlot/utils/qlot)
 
+(defvar *source-registry-exclusions*
+  '(".qlot" ".bundle-libs" ".direnv"))
+
 (defun dump-source-registry-conf (stream sources)
   (let ((*print-pretty* nil)
         (*print-case* :downcase))
@@ -20,7 +23,8 @@
             "~&(~{~S~^~% ~})~%"
             `(:source-registry
               :ignore-inherited-configuration
-              (:also-exclude ".qlot")
+              ,@(loop for exclude in *source-registry-exclusions*
+                      collect `(:also-exclude ,exclude))
               (:directory ,(asdf:system-source-directory :qlot))
               ,@(loop for source in sources
                       when (typep source 'source-local)

--- a/src/utils/qlot.lisp
+++ b/src/utils/qlot.lisp
@@ -14,7 +14,7 @@
 (in-package #:qlot/utils/qlot)
 
 (defvar *source-registry-exclusions*
-  '(".qlot" ".bundle-libs" ".direnv"))
+  '(".qlot" ".bundle-libs"))
 
 (defun dump-source-registry-conf (stream sources)
   (let ((*print-pretty* nil)


### PR DESCRIPTION
Adds `.bundle-libs` and `.direnv` to a list of exclusions to look for ASD files.
Rerunning of `qlot install` at each project root is required to apply these changes.

ref #232 