### PR TITLE
fix 'extract-tarball': flush tar-stream buffer before extract

### DIFF
--- a/src/utils/archive.lisp
+++ b/src/utils/archive.lisp
@@ -18,6 +18,7 @@
                                  :direction :output
                                  :element-type '(unsigned-byte 8))
         (deflate:inflate-gzip-stream in tar-stream)
+        (finish-output tar-stream)
         (archive:with-open-archive (archive tar-file)
           (prog1
               (merge-pathnames


### PR DESCRIPTION
sometimes qlot hangs on some github archives with the status `Extracting a tarball.`  This is caused by an incomplete tarball file.
