### PR TITLE
Fix metadata files for `ql` or `ultralisp`

### DIFF
--- a/src/install.lisp
+++ b/src/install.lisp
@@ -23,6 +23,7 @@
   (:import-from #:qlot/distify
                 #:distify)
   (:import-from #:qlot/logger
+                #:*debug*
                 #:*enable-whisper*
                 #:*terminal*
                 #:message
@@ -293,6 +294,7 @@ exec /bin/sh \"$CURRENT/../~A\" \"$@\"
                                    sources-non-local))))
                  (bt2:*default-special-bindings* (append `((*enable-color* . ,*enable-color*)
                                                            (*terminal* . ,*terminal*)
+                                                           (*debug* . ,*debug*)
                                                            (*enable-whisper* . nil)
                                                            (,(uiop:intern* '#:*fetch-scheme-functions* '#:ql-http) . ',(symbol-value (uiop:intern* '#:*fetch-scheme-functions* '#:ql-http))))
                                                          bt2:*default-special-bindings*))

--- a/src/progress.lisp
+++ b/src/progress.lisp
@@ -1,7 +1,8 @@
 (defpackage #:qlot/progress
   (:use #:cl)
   (:import-from #:qlot/logger
-                #:*terminal*)
+                #:*terminal*
+                #:*debug*)
   (:import-from #:qlot/color
                 #:color-text)
   (:import-from #:bordeaux-threads)
@@ -170,7 +171,8 @@
                                     (funcall (or job-header-fn #'princ-to-string) job))))
                     (handler-bind ((error
                                      (lambda (e)
-                                       (declare (ignore e))
+                                       (when *debug*
+                                         (uiop:print-condition-backtrace e))
                                        (when failed-fn
                                          (funcall failed-fn)))))
                       (funcall worker-fn job))))

--- a/src/utils.lisp
+++ b/src/utils.lisp
@@ -112,7 +112,7 @@ with the same key."
   (let ((buffer (make-array 1024 :element-type '(unsigned-byte 8))))
     (with-output-to-string (s)
       (loop for read-bytes = (read-sequence buffer stream)
-            do (write-string (map 'string #'code-char buffer) s)
+            do (write-string (map 'string #'code-char (subseq buffer 0 read-bytes)) s)
             while (= read-bytes 1024)))))
 
 (defun https-of (url)


### PR DESCRIPTION
The metadata files can be different if the line in releases.txt or systems.txt is longer than 1024.