### PR TITLE
Optimize project-searcher by not running unnecessarily.

### DIFF
--- a/local-init/qlot-99-setup.lisp
+++ b/local-init/qlot-99-setup.lisp
@@ -79,8 +79,9 @@
              (return system-file))))))))
 
 (defun add-system-definition-search-function ()
-  (pushnew 'project-system-searcher
-           asdf:*system-definition-search-functions*))
+  (setf asdf:*system-definition-search-functions*
+        (append asdf:*system-definition-search-functions*
+                (list 'project-system-searcher))))
 
 (setup-source-registry)
 (add-system-definition-search-function)

--- a/local-init/qlot-99-setup.lisp
+++ b/local-init/qlot-99-setup.lisp
@@ -51,30 +51,32 @@
         (make-system-cache :system-files system-files)))
 
 (defun project-system-searcher (system-name)
-  (block nil
-    (uiop:collect-sub*directories
-     *project-root*
-     (lambda (dir)
-       (let ((dirname (car (last (pathname-directory dir)))))
-         (and (stringp dirname)
-              (not (equal dirname ""))
-              (not (char= (aref dirname 0) #\.))
-              (not (find dirname asdf/source-registry:*default-source-registry-exclusions*
-                         :test 'equal)))))
-     t
-     (lambda (dir)
-       (let* ((system-files
-                (or (find-cache dir)
-                    (let ((asd-files
-                            (uiop:directory-files dir "*.asd")))
-                      (put-cache dir asd-files)
-                      asd-files)))
-              (system-file
-                (find system-name system-files
-                      :key #'pathname-name
-                      :test 'equal)))
-         (when system-file
-           (return system-file)))))))
+  (when (and (not (asdf:registered-system system-name))
+             (equal (asdf:primary-system-name system-name) system-name))
+    (block nil
+      (uiop:collect-sub*directories
+       *project-root*
+       (lambda (dir)
+         (let ((dirname (car (last (pathname-directory dir)))))
+           (and (stringp dirname)
+                (not (equal dirname ""))
+                (not (char= (aref dirname 0) #\.))
+                (not (find dirname asdf/source-registry:*default-source-registry-exclusions*
+                           :test 'equal)))))
+       t
+       (lambda (dir)
+         (let* ((system-files
+                  (or (find-cache dir)
+                      (let ((asd-files
+                              (uiop:directory-files dir "*.asd")))
+                        (put-cache dir asd-files)
+                        asd-files)))
+                (system-file
+                  (find system-name system-files
+                        :key #'pathname-name
+                        :test 'equal)))
+           (when system-file
+             (return system-file))))))))
 
 (defun add-system-definition-search-function ()
   (pushnew 'project-system-searcher


### PR DESCRIPTION
This will remedy a problem that was taking a long time when loading systems. Happens since v1.5.0.

ref #233