### PR TITLE
Fix local-init script to work on ECL (ASDF 3.1).

### DIFF
--- a/.github/workflows/ci-exec.yaml
+++ b/.github/workflows/ci-exec.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        lisp: [sbcl-bin, abcl-bin, ecl]
+        lisp: [sbcl-bin, abcl-bin, ecl, clasp-bin, ccl-bin]
         os: [ubuntu-latest]
       fail-fast: false
 

--- a/.github/workflows/ci-exec.yaml
+++ b/.github/workflows/ci-exec.yaml
@@ -1,0 +1,29 @@
+name: CI for qlot exec
+
+on: [push]
+
+jobs:
+  test:
+    name: ${{ matrix.lisp }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        lisp: [sbcl-bin, abcl-bin, ecl]
+        os: [ubuntu-latest]
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Install Roswell
+        env:
+          LISP: ${{ matrix.lisp }}
+          ROSWELL_INSTALL_DIR: /usr
+        run: |
+          curl -L https://raw.githubusercontent.com/roswell/roswell/master/scripts/install-for-ci.sh | sh
+      - name: Compile local-inits
+        run: |
+          for file in $(find ./local-init -name "*.lisp"); do
+            ros -e "(or (compile-file #P\"$file\") (uiop:quit -1))"
+          done

--- a/local-init/qlot-99-setup.lisp
+++ b/local-init/qlot-99-setup.lisp
@@ -51,7 +51,7 @@
         (make-system-cache :system-files system-files)))
 
 (defun project-system-searcher (system-name)
-  (when (and (not (asdf:registered-system system-name))
+  (when (and (not (asdf::registered-system system-name))
              (equal (asdf:primary-system-name system-name) system-name))
     (block nil
       (uiop:collect-sub*directories


### PR DESCRIPTION
Fixes #250.

Upgrading is not enough to fix it. Rerun `qlot install` to update scripts in `.qlot/local-init`.