### PR TITLE
Fix an error while retrieving the git ref for `github` sources.

### DIFF
--- a/src/http.lisp
+++ b/src/http.lisp
@@ -3,6 +3,8 @@
   (:shadow #:get)
   (:import-from #:qlot/proxy
                 #:*proxy*)
+  (:import-from #:qlot/logger
+                #:*debug*)
   (:import-from #:dexador)
   #-windows
   (:import-from #:cl+ssl)
@@ -23,6 +25,7 @@
            :if-exists :supersede
            :keep-alive nil
            :proxy *proxy*
+           :verbose *debug*
            (and basic-auth
                 (list :basic-auth basic-auth)))))
 
@@ -32,4 +35,5 @@
     (apply #'dex:get url
            :keep-alive nil
            :proxy *proxy*
+           :verbose *debug*
            args)))


### PR DESCRIPTION
It could fail when there are more than 30 branches. (Fix #252)