### PR TITLE
Show a specific error when trying to install an unknown library.

### DIFF
--- a/src/utils/quickdocs.lisp
+++ b/src/utils/quickdocs.lisp
@@ -1,6 +1,8 @@
 (defpackage #:qlot/utils/quickdocs
   (:use #:cl)
   (:import-from #:qlot/http)
+  (:import-from #:qlot/errors
+                #:qlot-simple-error)
   (:import-from #:quri)
   (:import-from #:yason)
   (:export #:project-upstream-url))
@@ -16,8 +18,13 @@
 
 (defun project-upstream-url (project-name)
   (let* ((project-info
-           (qlot/http:get (format nil "https://api.quickdocs.org/projects/~A"
-                                  (quri:url-encode project-name))))
+           (handler-case
+               (qlot/http:get (format nil "https://api.quickdocs.org/projects/~A"
+                                      (quri:url-encode project-name)))
+             (dex:http-request-not-found ()
+               (error 'qlot-simple-error
+                      :format-control "'~A' is not found."
+                      :format-arguments (list project-name)))))
          (upstream-url (gethash "upstream_url" (yason:parse project-info))))
     (unless (git-url-p upstream-url)
       (error "Not supported upstream URL: ~A" upstream-url))


### PR DESCRIPTION
```
$ qlot add dbi --upstream
qlot: 'dbi' is not found.
```

It should be `cl-dbi`.