### PR TITLE
Fix `qlot update` to allow to take `github`'s project names for update.

### DIFF
--- a/src/source/github.lisp
+++ b/src/source/github.lisp
@@ -49,21 +49,17 @@
                 (eql 1 (position-if #'keywordp initargs)))
       (setf project-name (pop initargs)))
     (destructuring-bind (repos &key ref branch tag) initargs
-      (apply #'make-instance 'source-github
-             :repos repos
-             :ref ref
-             :branch branch
-             :tag tag
-             (and project-name
-                  (list :project-name project-name))))))
-
-(defmethod prepare-source ((source source-github))
-  (unless (source-project-name source)
-    (let ((repos (source-github-repos source)))
-      (destructuring-bind (username repository)
-          (split-with #\/ repos)
-        (declare (ignore username))
-        (setf (source-project-name source) repository)))))
+      (unless project-name
+        (destructuring-bind (username repository)
+            (split-with #\/ repos)
+          (declare (ignore username))
+          (setf project-name repository)))
+      (make-instance 'source-github
+                     :repos repos
+                     :ref ref
+                     :branch branch
+                     :tag tag
+                     :project-name project-name))))
 
 (defmethod source-identifier ((source source-github))
   (source-github-repos source))

--- a/tests/install.lisp
+++ b/tests/install.lisp
@@ -74,9 +74,19 @@
               (merge-pathnames (format nil "dists/~A/software/" dist-name)
                                qlhome))))
 
+      (let ((data (parse-distinfo-file (merge-pathnames "dists/fukamachi-lack/distinfo.txt" qlhome))))
+        (ok (equal (aget data "version") "ultralisp-20190904101505")))
+
       (update-qlfile qlfile
                      :quicklisp-home qlhome
                      :projects '("fukamachi-lack"))
+
+      (let ((data (parse-distinfo-file (merge-pathnames "dists/lsx/distinfo.txt" qlhome))))
+        (ok (equal (aget data "version") "github-546032449c010e4153501accf1cac521")))
+
+      (update-qlfile qlfile
+                     :quicklisp-home qlhome
+                     :projects '("lsx"))
 
       (let ((data (parse-distinfo-file (merge-pathnames "dists/quicklisp/distinfo.txt" qlhome))))
         (ok (equal (aget data "version") "2018-02-28")))
@@ -87,7 +97,7 @@
       (let ((data (parse-distinfo-file (merge-pathnames "dists/cl-ppcre/distinfo.txt" qlhome))))
         (ok (equal (aget data "version") "ql-2018-08-31")))
       (let ((data (parse-distinfo-file (merge-pathnames "dists/lsx/distinfo.txt" qlhome))))
-        (ok (equal (aget data "version") "github-546032449c010e4153501accf1cac521")))
+        (ng (equal (aget data "version") "github-546032449c010e4153501accf1cac521")))
       (let ((data (parse-distinfo-file (merge-pathnames "dists/fukamachi-lack/distinfo.txt" qlhome))))
         (ng (equal (aget data "version") "ultralisp-20190904101505")))
       (let ((data (parse-distinfo-file (merge-pathnames "dists/mito/distinfo.txt" qlhome))))


### PR DESCRIPTION
Fix #285.