### PR TITLE
Make Windows-related changes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,25 @@
+# Linux
+*.sh text eol=lf
+*.screen text eol=lf
+
+## Lighttpd stuff
+*.conf text eol=lf
+*.pem text eol=lf
+*.crt text eol=lf
+
+# Windows
+*.ps1 text eol=crlf
+
+# Both OS's
+*.csv text
+# SBCL TRIPS UP on Carriage Returns
+*.lisp text eol=lf
+*.asd text eol=lf
+*.md text
+*.lock text
+qlfile text
+.gitignore text
+
+# Images
+*.png binary
+*.jpg binary

--- a/local-init/qlot-10-https.lisp
+++ b/local-init/qlot-10-https.lisp
@@ -45,10 +45,18 @@
 
 (defun which (cmd)
   (handler-case
-      (string-right-trim '(#\Newline)
-                         (with-output-to-string (s)
-                           (uiop:run-program `("which" ,cmd)
-                                             :output s)))
+    (let* ((cmd-output
+             (with-output-to-string (s)
+               (uiop:run-program #+win32
+                                 `("where" ,cmd)
+                                 #-win32
+                                 `("which" ,cmd)
+                                 :output s)))
+           (trim-at (position-if
+                      (lambda (c)
+                        (find c '(#\Newline #\Return)))
+                      cmd-output)))
+      (subseq cmd-output 0 trim-at))
     (uiop/run-program:subprocess-error ()
       nil)))
 

--- a/src/utils/cli.lisp
+++ b/src/utils/cli.lisp
@@ -49,9 +49,16 @@
 
 (defun exec (args)
   (assert args)
+  #+win32
+  (uiop:run-program
+    args
+    :input :interactive
+    :output :interactive
+    :error-output :interactive)
   #+(and unix sbcl)
   (execvp (first args) args)
   #-(and unix sbcl)
   (uiop:run-program args
                     :output t
                     :error-output t))
+


### PR DESCRIPTION
* Ensure the `which` function works on Windows
* Add a `gitattributes` file to ensure that when `ros install fukamachi/qlot` is run on Windows, the lisp files are NOT checked out with Windows line endings, as the carriage returns choke up SBCL
* Ensure that stdin and stdout are properly inherited on Windows so that the REPL doesn't just immediately exit when running `rsc qlot exec ros run`

The `rsc` command above is simply a batch file on the windows path, with this in it:

```
@echo off
ros -Q -L sbcl-bin -- "C:\Users\<USERNAME>\.roswell\lisp\quicklisp\bin\%*"
```