### PR TITLE
Disable parallel processing on windows to fix #289

### DIFF
--- a/src/progress.lisp
+++ b/src/progress.lisp
@@ -149,13 +149,13 @@
               (loop for (line . body) = (pop-queue *mailbox*)
                     do (refresh-progress-line manager line body)))
             :name "qlot progress manager")))
-    #+(or ecl clasp)
+    #+(or ecl clasp win32)
     (dolist (job jobs)
       (let ((*progress-line*
               (add-line manager
                         (funcall (or job-header-fn #'princ-to-string) job))))
         (funcall worker-fn job)))
-    #-(or ecl clasp)
+    #-(or ecl clasp win32)
     (let ((*kernel* (make-kernel concurrency
                                  :bindings bt2:*default-special-bindings*)))
       (unwind-protect


### PR DESCRIPTION
When parallel processing is enabled on Windows, reading the tarball to obtain an md5 hash when writing out the releases.txt file in the file `src/utils/distify.lisp` seems to segfault. Disabling processing on Windows solves the problem. Related to #289 .

Thanks!