### PR TITLE
Add ability to run from powershell or CMD prompt on Windows

### DIFF
--- a/roswell/qlot.bat
+++ b/roswell/qlot.bat
@@ -1,0 +1,4 @@
+@echo off
+setlocal
+set "this=%~dpn0"
+ros -Q -L sbcl-bin -- "%this%.ros"  %*


### PR DESCRIPTION
Right now, I can't just run `qlot install` on Windows from a CMD prompt. In order to do so, I have to have this script, named `rsc.bat`, on my PATH:

```batch
@echo off
ros -Q -L sbcl-bin -- C:\Users\bhw\.roswell\lisp\quicklisp\bin\%*
```

And run `rsc qlot install` instead.

This PR fixes this. By having a `.bat` file in the `roswell` directory, it gets installed into roswell's `bin/` folder, which is on the windows PATH. It finds itself in the file system, and runs the roswell script that is next to it within the same directory.

By adding this file, I can now just `ros install fukamachi/qlot` on Windows, followed by `qlot install` in my project directory, and it works.