### PR TITLE
Fix an unexpected error in `qlot outdated` due to missing a symbol import.

### DIFF
--- a/src/check.lisp
+++ b/src/check.lisp
@@ -37,7 +37,8 @@
                 #:qlfile-not-found
                 #:qlfile-lock-not-found
                 #:missing-projects
-                #:unnecessary-projects)
+                #:unnecessary-projects
+                #:outdated-projects)
   (:export #:check-qlfile
            #:check-project
            #:available-update-project))


### PR DESCRIPTION
Since 1.5.0.