### PR TITLE
Add `asdf` source to use a newer ASDF.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -340,7 +340,7 @@ Here are few useful commands:
 <source> <project name> [arg1, arg2..]
 ```
 
-Currently, `<source>` must be one of `dist`, `ql`, `ultralisp`, `http`, `git` or `github`.
+Currently, `<source>` must be one of `dist`, `ql`, `ultralisp`, `http`, `git`, `github`, `local` or `asdf`.
 
 ### ql
 
@@ -443,6 +443,18 @@ Add a directory to the ASDF's source registry.
 
 ```
 local rove ~/Programs/lib/rove
+```
+
+### asdf (Experimental)
+
+```
+asdf <version>
+```
+
+Use a newer version of ASDF.
+
+```
+asdf 3.3.7.1
 ```
 
 ### dist

--- a/src/check.lisp
+++ b/src/check.lisp
@@ -99,10 +99,12 @@
                                  (source-asdf
                                   (let ((asdf-dir (merge-pathnames #P"local-projects/asdf/" qlhome)))
                                     (and (uiop:directory-exists-p asdf-dir)
-                                         (progn
-                                           (asdf:load-asd (merge-pathnames #P"asdf.asd" asdf-dir))
-                                           (equal (asdf:asdf-version)
-                                                  (source-version source))))))
+                                         (let ((version-file (merge-pathnames #P"version.lisp-expr" asdf-dir)))
+                                           ;; XXX: Skip if the version file doesn't exist.
+                                           (or (not (uiop:file-exists-p version-file))
+                                               (ignore-errors
+                                                 (equal (uiop:read-file-form version-file)
+                                                        (source-version source))))))))
                                  (otherwise
                                   (let ((dist (find-dist (source-dist-name source))))
                                     (and dist

--- a/src/cli.lisp
+++ b/src/cli.lisp
@@ -524,7 +524,7 @@ OPTIONS:
 
       ;; Complete the source type
       (unless (member (first argv)
-                      '("dist" "git" "github" "http" "local" "ql" "ultralisp")
+                      '("dist" "git" "github" "http" "local" "ql" "ultralisp" "asdf")
                       :test 'equal)
         (setf argv
               (if (find #\/ (first argv) :test 'char=)

--- a/src/install.lisp
+++ b/src/install.lisp
@@ -64,7 +64,7 @@
                 #:tmp-directory
                 #:delete-tmp-directory)
   (:import-from #:qlot/utils/git
-                #:git-checkout
+                #:git-switch-tag
                 #:git-clone)
   (:import-from #:qlot/color
                 #:color-text
@@ -392,7 +392,7 @@ exec /bin/sh \"$CURRENT/../~A\" \"$@\"
          (cond
            ((uiop:directory-exists-p asdf-dir)
             ;; Tag switch
-            (git-checkout asdf-dir (source-version asdf-source)))
+            (git-switch-tag asdf-dir (source-version asdf-source)))
            (t
             (message "Downloading ASDF to '~A'." asdf-dir)
             ;; Clone

--- a/src/install.lisp
+++ b/src/install.lisp
@@ -11,6 +11,8 @@
                 #:source-local
                 #:source-local-path
                 #:source-local-registry-directive
+                #:source-asdf
+                #:source-asdf-remote-url
                 #:source-project-name
                 #:source-version
                 #:source-install-url
@@ -61,6 +63,9 @@
   (:import-from #:qlot/utils/tmp
                 #:tmp-directory
                 #:delete-tmp-directory)
+  (:import-from #:qlot/utils/git
+                #:git-checkout
+                #:git-clone)
   (:import-from #:qlot/color
                 #:color-text
                 #:*enable-color*)
@@ -280,7 +285,7 @@ exec /bin/sh \"$CURRENT/../~A\" \"$@\"
       (unwind-protect
            (let* ((sources-non-local
                     (remove-if (lambda (source)
-                                 (typep source 'source-local))
+                                 (typep source '(or source-local source-asdf)))
                                sources))
                   (sources-to-install
                     (with-quicklisp-home qlhome
@@ -376,6 +381,29 @@ exec /bin/sh \"$CURRENT/../~A\" \"$@\"
             (unless (find (name dist) sources :test #'string= :key #'source-dist-name)
               (message "Removing dist ~S." (name dist))
               (uninstall dist))))))
+
+    ;; ASDF
+    (let ((asdf-source (find-if (lambda (source)
+                                  (typep source 'source-asdf))
+                                sources))
+          (asdf-dir (merge-pathnames #P"local-projects/asdf/" qlhome)))
+      (cond
+        (asdf-source
+         (cond
+           ((uiop:directory-exists-p asdf-dir)
+            ;; Tag switch
+            (git-checkout asdf-dir (source-version asdf-source)))
+           (t
+            (message "Downloading ASDF to '~A'." asdf-dir)
+            ;; Clone
+            (git-clone (source-asdf-remote-url asdf-source)
+                       asdf-dir
+                       :checkout-to (source-version asdf-source)
+                       :recursive nil))))
+        (t
+         (when (uiop:directory-exists-p asdf-dir)
+           (message "Removing ASDF at '~A'." asdf-dir)
+           (uiop:delete-directory-tree asdf-dir :validate t :if-does-not-exist :ignore)))))
 
     (with-open-file (out (merge-pathnames #P"source-registry.conf" qlhome)
                          :direction :output

--- a/src/source.lisp
+++ b/src/source.lisp
@@ -6,4 +6,5 @@
                  #:qlot/source/github
                  #:qlot/source/dist
                  #:qlot/source/ultralisp
-                 #:qlot/source/local))
+                 #:qlot/source/local
+                 #:qlot/source/asdf))

--- a/src/source/asdf.lisp
+++ b/src/source/asdf.lisp
@@ -1,0 +1,26 @@
+(defpackage #:qlot/source/asdf
+  (:use #:cl
+        #:qlot/source/base)
+  (:export #:source-asdf
+           #:source-asdf-remote-url))
+(in-package #:qlot/source/asdf)
+
+(defclass source-asdf (source)
+  ((remote-url :initform "https://gitlab.common-lisp.net/asdf/asdf.git"
+               :accessor source-asdf-remote-url))
+  (:default-initargs
+   :project-name "asdf"))
+
+(defmethod usage-of-source ((source (eql :asdf)))
+  "asdf <version>")
+
+(defmethod make-source ((source (eql :asdf)) &rest initargs)
+  (destructuring-bind (version &rest args) initargs
+    (check-type version string)
+    (apply #'make-instance 'source-asdf
+           :version version
+           args)))
+
+(defmethod source= ((source1 source-asdf) (source2 source-asdf))
+  (string= (source-version source1)
+           (source-version source2)))

--- a/src/source/asdf.lisp
+++ b/src/source/asdf.lisp
@@ -22,5 +22,7 @@
            args)))
 
 (defmethod source= ((source1 source-asdf) (source2 source-asdf))
-  (string= (source-version source1)
-           (source-version source2)))
+  (and (string= (source-asdf-remote-url source1)
+                (source-asdf-remote-url source2))
+       (string= (source-version source1)
+                (source-version source2))))

--- a/src/utils/git.lisp
+++ b/src/utils/git.lisp
@@ -7,17 +7,25 @@
   (:import-from #:qlot/utils
                 #:split-with
                 #:starts-with)
-  (:export #:git-checkout
+  (:export #:git-switch-tag
            #:git-clone
            #:create-git-tarball
            #:git-ref))
 (in-package #:qlot/utils/git)
 
+(defun git-fetch (directory &rest args)
+  (safety-shell-command "git" `("-C" ,(uiop:native-namestring directory)
+                                "fetch" "--quiet" ,@args))
+  (values))
+
 (defun git-checkout (directory ref)
   (safety-shell-command "git" `("-C" ,(uiop:native-namestring directory)
-                                "fetch" "--quiet"))
-  (safety-shell-command "git" `("-C" ,(uiop:native-namestring directory)
                                 "checkout" ,ref "--quiet"))
+  (values))
+
+(defun git-switch-tag (directory tag)
+  (git-fetch directory "origin" (format nil "refs/tags/~A:refs/tags/~:*~A" tag) "--no-tags")
+  (git-checkout directory tag)
   (values))
 
 (defun git-clone (remote-url destination &key checkout-to ref (recursive t))
@@ -59,6 +67,7 @@
           (go git-cloning)))))
 
   (when ref
+    (git-fetch destination)
     (git-checkout destination ref)))
 
 (defun create-git-tarball (project-directory destination ref)


### PR DESCRIPTION
**Experimental feature**

Add a new source `asdf` to use a newer version of ASDF by downloading the source code to `.qlot/local-projects`.

ref #245

## Usage

### qlfile

```
asdf 3.3.7.1
```

### Command-line

```
$ qlot add asdf 3.3.7.1
```

## Limitations

* Only newer ASDF than the bundled one is permitted.

## TODO

- [x] Write README