### PR TITLE
Add `qlot.published-date` to distinfo.txt for `git` & `github` sources.

### DIFF
--- a/src/distify/git.lisp
+++ b/src/distify/git.lisp
@@ -103,7 +103,10 @@
                    :no-checkout (or distinfo-only
                                     (not (uiop:file-exists-p archive-file))))
         (progress "Writing the distinfo.")
-        (setf (source-published-at source) (git-committed-date source-directory))
+        (setf (source-published-at source)
+              ;; Convert the unix time to a universal one (from 1900-01-01).
+              (+ (* 25567 (* 60 60 24))
+                 (git-committed-date source-directory)))
         (write-source-distinfo source destination
                                (list :qlot.published-at (source-published-at source)))
 

--- a/src/distify/git.lisp
+++ b/src/distify/git.lisp
@@ -4,7 +4,8 @@
                 #:source-project-name
                 #:source-dist-name
                 #:source-version
-                #:source-version-prefix)
+                #:source-version-prefix
+                #:source-published-at)
   (:import-from #:qlot/source/git
                 #:source-git
                 #:source-git-branch
@@ -102,8 +103,9 @@
                    :no-checkout (or distinfo-only
                                     (not (uiop:file-exists-p archive-file))))
         (progress "Writing the distinfo.")
+        (setf (source-published-at source) (git-committed-date source-directory))
         (write-source-distinfo source destination
-                               (list :qlot.published-date (git-committed-date source-directory)))
+                               (list :qlot.published-at (source-published-at source)))
 
         (cond
           ((not (uiop:file-exists-p archive-file))

--- a/src/distify/github.lisp
+++ b/src/distify/github.lisp
@@ -120,6 +120,9 @@
     (ensure-directories-exist *default-pathname-defaults*)
 
     (progress "Writing the distinfo to ~S." destination)
+    ;; TODO: Stop making an extra API request just for getting the published time.
+    ;;   It is used only when using `qlot outdated`. Maybe it can be deferred until then?
+    #+todo
     (when (and (not distinfo-only)
                (not (source-published-at source)))
       (setf (source-published-at source)

--- a/src/source/base.lisp
+++ b/src/source/base.lisp
@@ -21,7 +21,6 @@
            #:source-dist-name
            #:source-identifier
            #:source=
-           #:write-distinfo
            #:source-install-url
            #:source-version-prefix))
 (in-package #:qlot/source/base)
@@ -136,21 +135,6 @@
     (and (eq (class-of source1) (class-of source2))
          (string= (source-project-name source1)
                   (source-project-name source2)))))
-
-(defun write-distinfo (source &optional (stream *standard-output*))
-  (format stream "~{~(~A~): ~A~%~}"
-          (list :name (source-dist-name source)
-                :version (source-version source)
-                :distinfo-subscription-url (format nil "qlot://localhost/~A.txt"
-                                                   (source-project-name source))
-                :canonical-distinfo-url (format nil "qlot://localhost/~A.txt"
-                                                (source-project-name source))
-                :release-index-url (format nil "qlot://localhost/~A/~A/releases.txt"
-                                           (source-project-name source)
-                                           (source-version source))
-                :system-index-url (format nil "qlot://localhost/~A/~A/systems.txt"
-                                          (source-project-name source)
-                                          (source-version source)))))
 
 (defgeneric source-install-url (source)
   (:method ((source source))

--- a/src/source/base.lisp
+++ b/src/source/base.lisp
@@ -10,6 +10,7 @@
   (:export #:source
            #:source-project-name
            #:source-version
+           #:source-published-at
            #:source-initargs
            #:source-defrost-args
            #:usage-of-source
@@ -31,6 +32,9 @@
                  :accessor source-project-name)
    (version :initarg :version
             :accessor source-version)
+   (published-at :initarg :published-at
+                 :initform nil
+                 :accessor source-published-at)
 
    ;; Keep these variables for dumping to qlfile.lock.
    (initargs :reader source-initargs)
@@ -87,7 +91,8 @@
 
 (defgeneric source-frozen-slots (source)
   (:method ((source source))
-    '()))
+    (and (source-published-at source)
+         `(:published-at ,(source-published-at source)))))
 
 (defgeneric freeze-source (source)
   (:method ((source source))

--- a/src/source/base.lisp
+++ b/src/source/base.lisp
@@ -91,8 +91,7 @@
 
 (defgeneric source-frozen-slots (source)
   (:method ((source source))
-    (and (source-published-at source)
-         `(:published-at ,(source-published-at source)))))
+    nil))
 
 (defgeneric freeze-source (source)
   (:method ((source source))

--- a/src/utils/distify.lisp
+++ b/src/utils/distify.lisp
@@ -16,10 +16,10 @@
                 #:https-of)
   (:import-from #:qlot/http)
   (:import-from #:qlot/source
+                #:source-dist-name
                 #:source-distinfo-url
                 #:source-project-name
-                #:source-version
-                #:write-distinfo)
+                #:source-version)
   (:import-from #:ironclad)
   (:export #:releases.txt
            #:systems.txt
@@ -117,10 +117,29 @@ Does not resolve symlinks, but PATH must actually exist in the filesystem."
          distribution
          version))))))
 
-(defun write-source-distinfo (source destination)
+(defun write-distinfo (distinfo.txt key-values)
+  (uiop:with-output-file (out distinfo.txt :if-exists :supersede)
+    (format out "~{~(~A~): ~A~%~}"
+            key-values)))
+
+(defun write-source-distinfo (source destination &optional additional-values)
   (let ((distinfo.txt (merge-pathnames
-                        (make-pathname :name (source-project-name source)
-                                       :type "txt")
-                        destination)))
-    (uiop:with-output-file (out distinfo.txt :if-exists :supersede)
-      (write-distinfo source out))))
+                       (make-pathname :name (source-project-name source)
+                                      :type "txt")
+                       destination))
+        (distinfo-key-values
+          (append
+           (list :name (source-dist-name source)
+                 :version (source-version source)
+                 :distinfo-subscription-url (format nil "qlot://localhost/~A.txt"
+                                                    (source-project-name source))
+                 :canonical-distinfo-url (format nil "qlot://localhost/~A.txt"
+                                                 (source-project-name source))
+                 :release-index-url (format nil "qlot://localhost/~A/~A/releases.txt"
+                                            (source-project-name source)
+                                            (source-version source))
+                 :system-index-url (format nil "qlot://localhost/~A/~A/systems.txt"
+                                           (source-project-name source)
+                                           (source-version source)))
+           additional-values)))
+    (write-distinfo distinfo.txt distinfo-key-values)))

--- a/src/utils/git.lisp
+++ b/src/utils/git.lisp
@@ -88,5 +88,7 @@
       (error "No git references named '~A'." ref-identifier))))
 
 (defun git-committed-date (repository-dir)
-  (safety-shell-command "git" `("-C" ,(uiop:native-namestring repository-dir)
-                                "log" "-1" "--format=%ct" "HEAD")))
+  (parse-integer
+   (string-right-trim '(#\Newline #\Return)
+                      (safety-shell-command "git" `("-C" ,(uiop:native-namestring repository-dir)
+                                                    "log" "-1" "--format=%ct" "HEAD")))))

--- a/tests/distify/git.lisp
+++ b/tests/distify/git.lisp
@@ -40,7 +40,9 @@
           (ok (equal (aget metadata "version") "git-64941e1848354767e08e57aca90d7c40350bb6b3"))
           (ok (equal (aget metadata "distinfo-subscription-url") "qlot://localhost/cl-dbi.txt"))
           (ok (equal (aget metadata "release-index-url") "qlot://localhost/cl-dbi/git-64941e1848354767e08e57aca90d7c40350bb6b3/releases.txt"))
-          (ok (equal (aget metadata "system-index-url") "qlot://localhost/cl-dbi/git-64941e1848354767e08e57aca90d7c40350bb6b3/systems.txt"))))
+          (ok (equal (aget metadata "system-index-url") "qlot://localhost/cl-dbi/git-64941e1848354767e08e57aca90d7c40350bb6b3/systems.txt"))
+          (ok (equal (aget metadata "qlot.published-at")
+                     "3776006654"))))
 
       (testing "systems.txt"
         (ok (uiop:file-exists-p systems.txt))

--- a/tests/distify/github.lisp
+++ b/tests/distify/github.lisp
@@ -34,7 +34,7 @@
       (ok (uiop:file-exists-p systems.txt))
 
       (ok (equal (uiop:read-file-string distinfo.txt)
-                 (format nil "name: quri~%version: github-adb6d04f1b9ea99fa7f18044df4c86b6c68023af~%distinfo-subscription-url: qlot://localhost/quri.txt~%canonical-distinfo-url: qlot://localhost/quri.txt~%release-index-url: qlot://localhost/quri/github-adb6d04f1b9ea99fa7f18044df4c86b6c68023af/releases.txt~%system-index-url: qlot://localhost/quri/github-adb6d04f1b9ea99fa7f18044df4c86b6c68023af/systems.txt~%qlot.published-at: 3776328306~%")))
+                 (format nil "name: quri~%version: github-adb6d04f1b9ea99fa7f18044df4c86b6c68023af~%distinfo-subscription-url: qlot://localhost/quri.txt~%canonical-distinfo-url: qlot://localhost/quri.txt~%release-index-url: qlot://localhost/quri/github-adb6d04f1b9ea99fa7f18044df4c86b6c68023af/releases.txt~%system-index-url: qlot://localhost/quri/github-adb6d04f1b9ea99fa7f18044df4c86b6c68023af/systems.txt~%")))
       (ok (equal (uiop:read-file-string releases.txt)
                  (format nil "# project url size file-md5 content-sha1 prefix [system-file1..system-fileN]~%quri qlot://localhost/quri/github-adb6d04f1b9ea99fa7f18044df4c86b6c68023af/archive.tar.gz 70532 fcfcb5d96ee6e34a37548be23984382f 2fbd8df6afd6fa4ac585da3ee17128ddd411061f quri-adb6d04f1b9ea99fa7f18044df4c86b6c68023af quri.asd quri-test.asd~%")))
       (ok (equal (uiop:read-file-string systems.txt)

--- a/tests/distify/github.lisp
+++ b/tests/distify/github.lisp
@@ -34,7 +34,7 @@
       (ok (uiop:file-exists-p systems.txt))
 
       (ok (equal (uiop:read-file-string distinfo.txt)
-                 (format nil "name: quri~%version: github-adb6d04f1b9ea99fa7f18044df4c86b6c68023af~%distinfo-subscription-url: qlot://localhost/quri.txt~%canonical-distinfo-url: qlot://localhost/quri.txt~%release-index-url: qlot://localhost/quri/github-adb6d04f1b9ea99fa7f18044df4c86b6c68023af/releases.txt~%system-index-url: qlot://localhost/quri/github-adb6d04f1b9ea99fa7f18044df4c86b6c68023af/systems.txt~%")))
+                 (format nil "name: quri~%version: github-adb6d04f1b9ea99fa7f18044df4c86b6c68023af~%distinfo-subscription-url: qlot://localhost/quri.txt~%canonical-distinfo-url: qlot://localhost/quri.txt~%release-index-url: qlot://localhost/quri/github-adb6d04f1b9ea99fa7f18044df4c86b6c68023af/releases.txt~%system-index-url: qlot://localhost/quri/github-adb6d04f1b9ea99fa7f18044df4c86b6c68023af/systems.txt~%qlot.published-at: 3776328306~%")))
       (ok (equal (uiop:read-file-string releases.txt)
                  (format nil "# project url size file-md5 content-sha1 prefix [system-file1..system-fileN]~%quri qlot://localhost/quri/github-adb6d04f1b9ea99fa7f18044df4c86b6c68023af/archive.tar.gz 70532 fcfcb5d96ee6e34a37548be23984382f 2fbd8df6afd6fa4ac585da3ee17128ddd411061f quri-adb6d04f1b9ea99fa7f18044df4c86b6c68023af quri.asd quri-test.asd~%")))
       (ok (equal (uiop:read-file-string systems.txt)


### PR DESCRIPTION
This will make it possible to provide date-based information in results. (ex. in `qlot outdated`)