### PR TITLE
Fix `github` projects to use the version specified in qlfile.lock.

### DIFF
--- a/src/source/github.lisp
+++ b/src/source/github.lisp
@@ -61,6 +61,12 @@
                      :tag tag
                      :project-name project-name))))
 
+(defmethod defrost-source :after ((source source-github))
+  (when (slot-boundp source 'qlot/source/base::version)
+    (setf (source-github-ref source)
+          (subseq (source-version source)
+                  (length (source-version-prefix source))))))
+
 (defmethod source-identifier ((source source-github))
   (source-github-repos source))
 

--- a/tests/data/qlfile5.lock
+++ b/tests/data/qlfile5.lock
@@ -17,7 +17,7 @@
 ("lsx" .
  (:class qlot.source.github:source-github
   :initargs (:project-name "lsx" :repos "fukamachi/lsx" :ref nil :branch nil :tag nil)
-  :version "github-546032449c010e4153501accf1cac521"))
+  :version "github-7c7c00ddd125810a67bee18534d34b7a6fc84a0a"))
 ("fukamachi-lack" .
  (:class qlot.source.ultralisp:source-ultralisp
   :initargs (:project-name "fukamachi-lack" :%version :latest)

--- a/tests/install.lisp
+++ b/tests/install.lisp
@@ -53,7 +53,7 @@
       (let ((data (parse-distinfo-file (merge-pathnames "dists/cl-ppcre/distinfo.txt" qlhome))))
         (ok (equal (aget data "version") "ql-2018-08-31")))
       (let ((data (parse-distinfo-file (merge-pathnames "dists/lsx/distinfo.txt" qlhome))))
-        (ok (equal (aget data "version") "github-546032449c010e4153501accf1cac521")))
+        (ok (equal (aget data "version") "github-7c7c00ddd125810a67bee18534d34b7a6fc84a0a")))
       (let ((data (parse-distinfo-file (merge-pathnames "dists/fukamachi-lack/distinfo.txt" qlhome))))
         (ok (equal (aget data "version") "ultralisp-20190904101505")))
       (let ((data (parse-distinfo-file (merge-pathnames "dists/mito/distinfo.txt" qlhome))))
@@ -82,7 +82,7 @@
                      :projects '("fukamachi-lack"))
 
       (let ((data (parse-distinfo-file (merge-pathnames "dists/lsx/distinfo.txt" qlhome))))
-        (ok (equal (aget data "version") "github-546032449c010e4153501accf1cac521")))
+        (ok (equal (aget data "version") "github-7c7c00ddd125810a67bee18534d34b7a6fc84a0a")))
 
       (update-qlfile qlfile
                      :quicklisp-home qlhome
@@ -97,7 +97,7 @@
       (let ((data (parse-distinfo-file (merge-pathnames "dists/cl-ppcre/distinfo.txt" qlhome))))
         (ok (equal (aget data "version") "ql-2018-08-31")))
       (let ((data (parse-distinfo-file (merge-pathnames "dists/lsx/distinfo.txt" qlhome))))
-        (ng (equal (aget data "version") "github-546032449c010e4153501accf1cac521")))
+        (ng (equal (aget data "version") "github-7c7c00ddd125810a67bee18534d34b7a6fc84a0a")))
       (let ((data (parse-distinfo-file (merge-pathnames "dists/fukamachi-lack/distinfo.txt" qlhome))))
         (ng (equal (aget data "version") "ultralisp-20190904101505")))
       (let ((data (parse-distinfo-file (merge-pathnames "dists/mito/distinfo.txt" qlhome))))


### PR DESCRIPTION
Currently, it always uses the latest version of the branch.
