### PR TITLE
Update README to fix issues and include option for people using Vim but not Roswell

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -530,12 +530,7 @@ See the [Sly manual](https://joaotavora.github.io/sly/#Multiple-Lisps) to set up
 
 ### Vim/Neovim
 
-# Setting up Vlime with Qlot
-
-## Installation Steps
-
 1. Install [vlime/vlime](https://github.com/vlime/vlime)
-
 2. Add the appropriate configuration to your Vim/Neovim `init.vim`:
 
    #### If you use Roswell:
@@ -567,7 +562,6 @@ See the [Sly manual](https://joaotavora.github.io/sly/#Multiple-Lisps) to set up
    ```
 
 3. Relaunch Vim/Neovim
-
 4. Navigate to your project directory with `:cd /path/to/project/` and start Vlime with `:call VlimeQlotExec()`
 
 ## Working with local git repositories

--- a/README.markdown
+++ b/README.markdown
@@ -530,24 +530,45 @@ See the [Sly manual](https://joaotavora.github.io/sly/#Multiple-Lisps) to set up
 
 ### Vim/Neovim
 
-1. Install [vlime/vlime](https://github.com/vlime/vlime).
-2. Add the following code to your Vim/Neovim init.vim.
+# Setting up Vlime with Qlot
 
-```vimscript
-let g:vlime_cl_use_terminal = v:true
-let s:vlime_path = '/path/to/vlime'
-function! VlimeBuildServerCommandFor_qlot(vlime_loader, vlime_eval)
-    return ["qlot", "exec", "ros", "run",
-               \ "--load", s:vlime_path . "/lisp/load-vlime.lisp",
-               \ "--eval", vlime_eval]
-endfunction
-function! VlimeQlotExec()
-    call vlime#server#New(v:true, get(g:, "vlime_cl_use_terminal", v:false), v:null, "qlot")
-endfunction
-```
+## Installation Steps
 
-3. Relaunch the Vim/Neovim.
-4. Change the directory by `:cd /path/to/project/` and invoke `:call VlimeQlotExec()`.
+1. Install [vlime/vlime](https://github.com/vlime/vlime)
+
+2. Add the appropriate configuration to your Vim/Neovim `init.vim`:
+
+   #### If you use Roswell:
+   ```vim
+   let g:vlime_cl_use_terminal = v:true
+   let s:vlime_path = '/path/to/vlime'
+   function! VlimeBuildServerCommandFor_qlot(vlime_loader, vlime_eval)
+       return ["qlot", "exec", "ros", "run",
+                 \ "--load", s:vlime_path . "/lisp/load-vlime.lisp",
+                 \ "--eval", a:vlime_eval]
+   endfunction
+   function! VlimeQlotExec()
+       call vlime#server#New(v:true, get(g:, "vlime_cl_use_terminal", v:false), v:null, "qlot")
+   endfunction
+   ```
+
+   #### If you use plain SBCL:
+   ```vim
+   let g:vlime_cl_use_terminal = v:true
+   let s:vlime_path = '/path/to/vlime'
+   function! VlimeBuildServerCommandFor_qlot(vlime_loader, vlime_eval)
+       return ["qlot", "exec", "sbcl",
+                 \ "--load", s:vlime_path . "/lisp/load-vlime.lisp",
+                 \ "--eval", a:vlime_eval]
+   endfunction
+   function! VlimeQlotExec()
+       call vlime#server#New(v:true, get(g:, "vlime_cl_use_terminal", v:false), v:null, "qlot")
+   endfunction
+   ```
+
+3. Relaunch Vim/Neovim
+
+4. Navigate to your project directory with `:cd /path/to/project/` and start Vlime with `:call VlimeQlotExec()`
 
 ## Working with local git repositories
 


### PR DESCRIPTION
Fixed the README documentation, in particular on the Vim/Neovim part regarding Vlime setup. The parameter to the `--eval` flag was not properly prefixed as parameters should be in vimscript.

Further, I updated the README to include a setup option using Vlime for those not using Roswell as a starting point. This caused issues in my own local setup. The alternative I added shows the example of using SBCL, but I am as of yet unsure how it would look like using other implementations. I believe it to be fine, since most people use SBCL, and so the chances of it being spot-on are higher than, well, not having anything of the sort.

See #313.