### PR TITLE
Fix generate a cache-key for ql-dist entries

### DIFF
--- a/src/cache.lisp
+++ b/src/cache.lisp
@@ -8,6 +8,9 @@
   (:import-from #:qlot/source/ql
                 #:source-ql
                 #:source-ql-upstream)
+  (:import-from #:qlot/source/ql-dist
+                #:source-ql-dist
+                #:source-ql-dist-dist-name)
   (:import-from #:qlot/source/ultralisp
                 #:source-ultralisp)
   (:import-from #:qlot/source/dist
@@ -149,6 +152,13 @@ release hook handles caching. Only metadata needs source-level caching."
 (defmethod cache-key ((source source-ql))
   (when (slot-boundp source 'qlot/source/base::version)
     (list "ql" "quicklisp"
+          (format nil "~A-~A"
+                  (source-project-name source)
+                  (source-version source)))))
+
+(defmethod cache-key ((source source-ql-dist))
+  (when (slot-boundp source 'qlot/source/base::version)
+    (list "ql" (source-ql-dist-dist-name source)
           (format nil "~A-~A"
                   (source-project-name source)
                   (source-version source)))))


### PR DESCRIPTION
Fixes a bug caused when adding a custom key like

```
dist http://quicklisp.e.drongo.info/dist/quicklisp.txt
ql-dist quicklisp-mirror fiveam
```

```
$ qlot install
...
Unexpected error: There is no applicable method for the generic function
                    #<STANDARD-GENERIC-FUNCTION QLOT/CACHE:CACHE-KEY (6)>
                  when called with arguments
                    (#<QLOT/SOURCE/QL-DIST:SOURCE-QL-DIST quicklisp-mirror fiveam LATEST {1201A048C3}>).
See also:
  The ANSI Standard, Section 7.6.6
```