### PR TITLE
Fix qlot bundle for local project dependencies

### DIFF
--- a/qlot-tests.asd
+++ b/qlot-tests.asd
@@ -21,7 +21,8 @@
                "qlot-tests/cache-releases"
                "qlot-tests/utils"
                "qlot-tests/utils/ql"
-               "qlot-tests/utils/asdf")
+               "qlot-tests/utils/asdf"
+               "qlot-tests/bundle")
   :perform (test-op (op c) (symbol-call :rove :run c)))
 
 ;; Tests that require patched quicklisp-client (with *install-release-hook*).

--- a/src/bundle.lisp
+++ b/src/bundle.lisp
@@ -10,13 +10,16 @@
                 #:with-quicklisp-home)
   (:import-from #:qlot/utils/asdf
                 #:with-source-registry)
+  (:import-from #:qlot/cache
+                #:create-symlink)
   (:import-from #:qlot/utils
                 #:with-package-functions
                 #:ensure-package-loaded)
   (:import-from #:qlot/logger
                 #:message)
   (:export #:bundle-project
-           #:local-project-paths-from-registry-conf))
+           #:local-project-paths-from-registry-conf
+           #:create-local-project-symlinks))
 (in-package #:qlot/bundle)
 
 (defun release-installed-directory (release)
@@ -106,6 +109,19 @@ Returns nil if the file does not exist or cannot be parsed."
                   into paths
                 finally (return (remove nil paths))))))))
 
+(defun create-local-project-symlinks (local-project-paths bundle-directory)
+  "Create symlinks in BUNDLE-DIRECTORY/local-projects/ for each path in LOCAL-PROJECT-PATHS.
+Each symlink is named after the directory basename of the project path.
+Non-existent paths are skipped."
+  (ensure-directories-exist (merge-pathnames #P"local-projects/" bundle-directory))
+  (dolist (path local-project-paths)
+    (when (uiop:directory-exists-p path)
+      (let* ((name (car (last (pathname-directory path))))
+             (link (merge-pathnames (format nil "local-projects/~A" name)
+                                    bundle-directory)))
+        (create-symlink (uiop:native-namestring path)
+                        (uiop:native-namestring link))))))
+
 (defun %bundle-project (project-root &key exclude output)
   (assert (uiop:absolute-pathname-p project-root))
 
@@ -180,6 +196,7 @@ Returns nil if the file does not exist or cannot be parsed."
                                :if-exists :overwrite
                                :if-does-not-exist :create
                                :direction :output))
+          (create-local-project-symlinks local-project-paths bundle-directory)
           (message "Successfully bundled at '~A'." bundle-directory))))))
 
 (defun bundle-project (object &key exclude output)

--- a/src/bundle.lisp
+++ b/src/bundle.lisp
@@ -10,6 +10,11 @@
                 #:with-quicklisp-home)
   (:import-from #:qlot/utils/asdf
                 #:with-source-registry)
+  (:import-from #:qlot/parser
+                #:parse-qlfile)
+  (:import-from #:qlot/source
+                #:source-local
+                #:source-local-path)
   (:import-from #:qlot/cache
                 #:create-symlink)
   (:import-from #:qlot/utils
@@ -18,7 +23,7 @@
   (:import-from #:qlot/logger
                 #:message)
   (:export #:bundle-project
-           #:local-project-paths-from-registry-conf
+           #:local-project-paths
            #:create-local-project-symlinks))
 (in-package #:qlot/bundle)
 
@@ -83,31 +88,30 @@ would otherwise fail because the qlot server isn't running during bundle."
 
 (defvar *default-bundle-directory-name* ".bundle-libs")
 
-(defun resolve-registry-tree-directive (dir-spec quicklisp-home)
-  "Resolve a single source-registry :tree directive to a pathname."
-  (cond
-    ((and (consp dir-spec) (eq :here (first dir-spec)))
-     (uiop:ensure-directory-pathname
-      (merge-pathnames (second dir-spec) quicklisp-home)))
-    ((and (consp dir-spec) (eq :home (first dir-spec)))
-     (uiop:ensure-directory-pathname
-      (merge-pathnames (second dir-spec) (user-homedir-pathname))))
-    ((pathnamep dir-spec)
-     dir-spec)
-    (t nil)))
+(defun resolve-local-path (path project-root)
+  "Resolve a local project PATH relative to PROJECT-ROOT.
+PATH may be a relative path, absolute path, or ~/prefixed path."
+  (let ((path (etypecase path
+                (string path)
+                (pathname (namestring path)))))
+    (uiop:ensure-directory-pathname
+     (cond
+       ((uiop:absolute-pathname-p path)
+        (pathname path))
+       ((and (<= 2 (length path))
+             (string= path "~/" :end1 2))
+        (merge-pathnames (subseq path 2) (user-homedir-pathname)))
+       (t
+        (uiop:subpathname project-root path))))))
 
-(defun local-project-paths-from-registry-conf (quicklisp-home)
-  "Return local project paths declared in QUICKLISP-HOME/source-registry.conf.
-Returns nil if the file does not exist or cannot be parsed."
-  (let ((conf-file (merge-pathnames #P"source-registry.conf" quicklisp-home)))
-    (when (uiop:file-exists-p conf-file)
-      (let ((registry (ignore-errors (uiop:read-file-form conf-file))))
-        (when (and (consp registry) (eq :source-registry (first registry)))
-          (loop for entry in (rest registry)
-                when (and (consp entry) (eq :tree (first entry)))
-                  collect (resolve-registry-tree-directive (second entry) quicklisp-home)
-                  into paths
-                finally (return (remove nil paths))))))))
+(defun local-project-paths (project-root)
+  "Return absolute directory pathnames for local projects declared in the qlfile."
+  (let ((qlfile (merge-pathnames #P"qlfile" project-root)))
+    (when (uiop:file-exists-p qlfile)
+      (loop for source in (parse-qlfile qlfile)
+            when (typep source 'source-local)
+              collect (resolve-local-path (source-local-path source)
+                                          project-root)))))
 
 (defun create-local-project-symlinks (local-project-paths bundle-directory)
   "Create symlinks in BUNDLE-DIRECTORY/local-projects/ for each path in LOCAL-PROJECT-PATHS.
@@ -141,7 +145,7 @@ Non-existent paths are skipped."
       (let* ((bundle-directory (uiop:ensure-directory-pathname
                                  (merge-pathnames (or output *default-bundle-directory-name*)
                                                   project-root)))
-             (local-project-paths (local-project-paths-from-registry-conf quicklisp-home))
+             (local-project-paths (local-project-paths project-root))
              (dependencies (with-package-functions #:ql-dist (find-system)
                              (mapcar #'find-system
                                      (project-dependencies-in-child-process project-root quicklisp-home

--- a/src/bundle.lisp
+++ b/src/bundle.lisp
@@ -15,7 +15,8 @@
                 #:ensure-package-loaded)
   (:import-from #:qlot/logger
                 #:message)
-  (:export #:bundle-project))
+  (:export #:bundle-project
+           #:local-project-paths-from-registry-conf))
 (in-package #:qlot/bundle)
 
 (defun release-installed-directory (release)
@@ -79,6 +80,32 @@ would otherwise fail because the qlot server isn't running during bundle."
 
 (defvar *default-bundle-directory-name* ".bundle-libs")
 
+(defun resolve-registry-tree-directive (dir-spec quicklisp-home)
+  "Resolve a single source-registry :tree directive to a pathname."
+  (cond
+    ((and (consp dir-spec) (eq :here (first dir-spec)))
+     (uiop:ensure-directory-pathname
+      (merge-pathnames (second dir-spec) quicklisp-home)))
+    ((and (consp dir-spec) (eq :home (first dir-spec)))
+     (uiop:ensure-directory-pathname
+      (merge-pathnames (second dir-spec) (user-homedir-pathname))))
+    ((pathnamep dir-spec)
+     dir-spec)
+    (t nil)))
+
+(defun local-project-paths-from-registry-conf (quicklisp-home)
+  "Return local project paths declared in QUICKLISP-HOME/source-registry.conf.
+Returns nil if the file does not exist or cannot be parsed."
+  (let ((conf-file (merge-pathnames #P"source-registry.conf" quicklisp-home)))
+    (when (uiop:file-exists-p conf-file)
+      (let ((registry (ignore-errors (uiop:read-file-form conf-file))))
+        (when (and (consp registry) (eq :source-registry (first registry)))
+          (loop for entry in (rest registry)
+                when (and (consp entry) (eq :tree (first entry)))
+                  collect (resolve-registry-tree-directive (second entry) quicklisp-home)
+                  into paths
+                finally (return (remove nil paths))))))))
+
 (defun %bundle-project (project-root &key exclude output)
   (assert (uiop:absolute-pathname-p project-root))
 
@@ -98,12 +125,15 @@ would otherwise fail because the qlot server isn't running during bundle."
       (let* ((bundle-directory (uiop:ensure-directory-pathname
                                  (merge-pathnames (or output *default-bundle-directory-name*)
                                                   project-root)))
+             (local-project-paths (local-project-paths-from-registry-conf quicklisp-home))
              (dependencies (with-package-functions #:ql-dist (find-system)
                              (mapcar #'find-system
                                      (project-dependencies-in-child-process project-root quicklisp-home
                                                                             :exclude exclude
                                                                             :ignore-directories
-                                                                            (list bundle-directory)))))
+                                                                            (list bundle-directory)
+                                                                            :local-project-paths
+                                                                            local-project-paths))))
              (dep-releases (with-package-functions #:ql-dist (release name)
                              (delete-duplicates
                               (mapcar #'release dependencies)
@@ -118,6 +148,7 @@ would otherwise fail because the qlot server isn't running during bundle."
               (with-package-functions #:ql (bundle-systems)
                 (with-source-registry (`(:source-registry :ignore-inherited-configuration
                                          (:tree ,project-root)
+                                         ,@(mapcar (lambda (path) `(:tree ,path)) local-project-paths)
                                          (:also-exclude ".qlot")
                                          (:also-exclude ,(uiop:native-namestring bundle-directory))))
                   (with-qlot-unpack-release

--- a/src/bundle.lisp
+++ b/src/bundle.lisp
@@ -14,7 +14,7 @@
                 #:parse-qlfile)
   (:import-from #:qlot/source
                 #:source-local
-                #:source-local-path)
+                #:source-local-absolute-path)
   (:import-from #:qlot/cache
                 #:create-symlink)
   (:import-from #:qlot/utils
@@ -88,30 +88,13 @@ would otherwise fail because the qlot server isn't running during bundle."
 
 (defvar *default-bundle-directory-name* ".bundle-libs")
 
-(defun resolve-local-path (path project-root)
-  "Resolve a local project PATH relative to PROJECT-ROOT.
-PATH may be a relative path, absolute path, or ~/prefixed path."
-  (let ((path (etypecase path
-                (string path)
-                (pathname (namestring path)))))
-    (uiop:ensure-directory-pathname
-     (cond
-       ((uiop:absolute-pathname-p path)
-        (pathname path))
-       ((and (<= 2 (length path))
-             (string= path "~/" :end1 2))
-        (merge-pathnames (subseq path 2) (user-homedir-pathname)))
-       (t
-        (uiop:subpathname project-root path))))))
-
 (defun local-project-paths (project-root)
   "Return absolute directory pathnames for local projects declared in the qlfile."
   (let ((qlfile (merge-pathnames #P"qlfile" project-root)))
     (when (uiop:file-exists-p qlfile)
       (loop for source in (parse-qlfile qlfile)
             when (typep source 'source-local)
-              collect (resolve-local-path (source-local-path source)
-                                          project-root)))))
+              collect (source-local-absolute-path source project-root)))))
 
 (defun create-local-project-symlinks (local-project-paths bundle-directory)
   "Create symlinks in BUNDLE-DIRECTORY/local-projects/ for each path in LOCAL-PROJECT-PATHS.

--- a/src/cache.lisp
+++ b/src/cache.lisp
@@ -53,7 +53,8 @@
            #:release-cache-exists-p
            #:restore-release-from-cache
            #:save-release-to-cache
-           #:symlink-p))
+           #:symlink-p
+           #:create-symlink))
 (in-package #:qlot/cache)
 
 (defvar *cache-directory*

--- a/src/source/local.lisp
+++ b/src/source/local.lisp
@@ -7,7 +7,8 @@
                 #:starts-with)
   (:export #:source-local
            #:source-local-path
-           #:source-local-registry-directive))
+           #:source-local-registry-directive
+           #:source-local-absolute-path))
 (in-package #:qlot/source/local)
 
 (defclass source-local (source)
@@ -35,6 +36,21 @@
 (defun source-local-registry-directive (source)
   (check-type source source-local)
   (convert-local-path (source-local-path source)))
+
+(defun source-local-absolute-path (source project-root)
+  "Return the absolute directory pathname for SOURCE resolved relative to PROJECT-ROOT."
+  (check-type source source-local)
+  (let ((path (source-local-path source)))
+    (uiop:ensure-directory-pathname
+     (etypecase path
+       (pathname path)
+       (string
+        (cond
+          ((uiop:absolute-pathname-p path) (pathname path))
+          ((starts-with "~/" path)
+           (merge-pathnames (subseq path 2) (user-homedir-pathname)))
+          (t
+           (uiop:subpathname project-root path))))))))
 
 (defmethod usage-of-source ((source (eql :local)))
   "local <project name> <directory path>")

--- a/src/utils/dependencies.lisp
+++ b/src/utils/dependencies.lisp
@@ -13,7 +13,7 @@
 (in-package #:qlot/utils/dependencies)
 
 (defun project-dependencies-in-child-process (project-root quicklisp-home
-                                              &key exclude ignore-directories)
+                                              &key exclude ignore-directories local-project-paths)
   (uiop:with-temporary-file (:pathname tmp)
     (run-lisp `((load ,(merge-pathnames #P"setup.lisp" quicklisp-home))
                 (setf *enable-color* ,*enable-color*)
@@ -26,8 +26,13 @@
                     (mapcar
                      (lambda (cl-user::dep)
                        (uiop:symbol-call '#:ql-dist '#:name cl-user::dep))
-                     (project-dependencies ,project-root :exclude (list ,@exclude)
-                                           :ignore-directories (list ,@ignore-directories)))
+                     (nconc
+                      (project-dependencies ,project-root :exclude (list ,@exclude)
+                                            :ignore-directories (list ,@ignore-directories))
+                      ,@(mapcar (lambda (path)
+                                  `(project-dependencies ,path
+                                                         :ignore-directories (list ,@ignore-directories)))
+                                local-project-paths)))
                     :test 'equal
                     :from-end t)
                    cl-user::out)))

--- a/tests/bundle.lisp
+++ b/tests/bundle.lisp
@@ -1,0 +1,112 @@
+(defpackage #:qlot-tests/bundle
+  (:use #:cl
+        #:rove)
+  (:import-from #:qlot/bundle
+                #:local-project-paths-from-registry-conf)
+  (:import-from #:qlot/utils/tmp
+                #:with-tmp-directory))
+(in-package #:qlot-tests/bundle)
+
+(defun write-registry-conf (dir &rest tree-entries)
+  "Write a source-registry.conf to DIR with the given :tree entries."
+  (let ((conf-file (merge-pathnames #P"source-registry.conf" dir)))
+    (with-open-file (out conf-file
+                         :direction :output
+                         :if-exists :supersede
+                         :if-does-not-exist :create)
+      (let ((*print-pretty* nil) (*print-case* :downcase))
+        (prin1 `(:source-registry
+                 :ignore-inherited-configuration
+                 (:also-exclude ".qlot")
+                 (:also-exclude ".bundle-libs")
+                 (:directory "/some/qlot/src/")
+                 ,@tree-entries)
+               out)))
+    conf-file))
+
+(deftest local-project-paths-from-registry-conf-tests
+  (testing "returns nil when source-registry.conf does not exist"
+    (with-tmp-directory (tmp)
+      (ok (null (local-project-paths-from-registry-conf tmp)))))
+
+  (testing "returns nil when source-registry.conf has no :tree entries"
+    (with-tmp-directory (tmp)
+      (write-registry-conf tmp)
+      (ok (null (local-project-paths-from-registry-conf tmp)))))
+
+  (testing "extracts :here relative path"
+    (with-tmp-directory (tmp)
+      ;; (:here #P"../mylib/") is relative to the .qlot dir (tmp)
+      (let ((resolved (uiop:ensure-directory-pathname
+                       (merge-pathnames #P"../mylib/" tmp))))
+        (write-registry-conf tmp `(:tree (:here #P"../mylib/")))
+        (let ((paths (local-project-paths-from-registry-conf tmp)))
+          (ok (= 1 (length paths)))
+          (ok (uiop:pathname-equal resolved (first paths)))))))
+
+  (testing "extracts absolute pathname"
+    (with-tmp-directory (tmp)
+      (with-tmp-directory (local-proj)
+        (write-registry-conf tmp `(:tree ,local-proj))
+        (let ((paths (local-project-paths-from-registry-conf tmp)))
+          (ok (= 1 (length paths)))
+          (ok (uiop:pathname-equal local-proj (first paths)))))))
+
+  (testing "extracts multiple :tree entries"
+    (with-tmp-directory (tmp)
+      (with-tmp-directory (proj-a)
+        (with-tmp-directory (proj-b)
+          (write-registry-conf tmp
+                               `(:tree ,proj-a)
+                               `(:tree ,proj-b))
+          (let ((paths (local-project-paths-from-registry-conf tmp)))
+            (ok (= 2 (length paths))))))))
+
+  (testing "skips :directory entries (not local projects)"
+    (with-tmp-directory (tmp)
+      ;; Only :tree entries should be returned; :directory (qlot src) is skipped
+      (write-registry-conf tmp)
+      (let ((paths (local-project-paths-from-registry-conf tmp)))
+        (ok (null paths)))))
+
+  (testing "extracts :home directive path"
+    (with-tmp-directory (tmp)
+      ;; (:home #P"mylib/") represents ~/mylib/ - should be resolved
+      (write-registry-conf tmp `(:tree (:home #P"mylib/")))
+      (let ((paths (local-project-paths-from-registry-conf tmp)))
+        (ok (= 1 (length paths)))
+        ;; The resolved path should end in mylib/ under the user home
+        (ok (uiop:pathname-equal
+             (merge-pathnames #P"mylib/" (user-homedir-pathname))
+             (first paths))))))
+
+  (testing "returns nil for malformed source-registry.conf"
+    (with-tmp-directory (tmp)
+      ;; Write garbage that is not valid s-expression
+      (let ((conf-file (merge-pathnames #P"source-registry.conf" tmp)))
+        (with-open-file (out conf-file
+                             :direction :output
+                             :if-exists :supersede
+                             :if-does-not-exist :create)
+          (write-string "this is not valid ( lisp" out)))
+      (ok (null (local-project-paths-from-registry-conf tmp)))))
+
+  (testing "returns nil for empty source-registry.conf"
+    (with-tmp-directory (tmp)
+      (let ((conf-file (merge-pathnames #P"source-registry.conf" tmp)))
+        (with-open-file (out conf-file
+                             :direction :output
+                             :if-exists :supersede
+                             :if-does-not-exist :create)
+          ;; Write empty file
+          ))
+      (ok (null (local-project-paths-from-registry-conf tmp)))))
+
+  (testing "returned paths are directory pathnames"
+    (with-tmp-directory (tmp)
+      (with-tmp-directory (local-proj)
+        (write-registry-conf tmp `(:tree ,local-proj))
+        (let ((paths (local-project-paths-from-registry-conf tmp)))
+          (ok (= 1 (length paths)))
+          ;; Must be a directory pathname (trailing slash)
+          (ok (uiop:directory-pathname-p (first paths))))))))

--- a/tests/bundle.lisp
+++ b/tests/bundle.lisp
@@ -2,7 +2,7 @@
   (:use #:cl
         #:rove)
   (:import-from #:qlot/bundle
-                #:local-project-paths-from-registry-conf
+                #:local-project-paths
                 #:create-local-project-symlinks)
   (:import-from #:qlot/cache
                 #:symlink-p)
@@ -10,108 +10,64 @@
                 #:with-tmp-directory))
 (in-package #:qlot-tests/bundle)
 
-(defun write-registry-conf (dir &rest tree-entries)
-  "Write a source-registry.conf to DIR with the given :tree entries."
-  (let ((conf-file (merge-pathnames #P"source-registry.conf" dir)))
-    (with-open-file (out conf-file
+(defun write-qlfile (dir &rest lines)
+  "Write a qlfile to DIR with the given lines."
+  (let ((qlfile (merge-pathnames #P"qlfile" dir)))
+    (with-open-file (out qlfile
                          :direction :output
                          :if-exists :supersede
                          :if-does-not-exist :create)
-      (let ((*print-pretty* nil) (*print-case* :downcase))
-        (prin1 `(:source-registry
-                 :ignore-inherited-configuration
-                 (:also-exclude ".qlot")
-                 (:also-exclude ".bundle-libs")
-                 (:directory "/some/qlot/src/")
-                 ,@tree-entries)
-               out)))
-    conf-file))
+      (dolist (line lines)
+        (write-line line out)))
+    qlfile))
 
-(deftest local-project-paths-from-registry-conf-tests
-  (testing "returns nil when source-registry.conf does not exist"
+(deftest local-project-paths-tests
+  (testing "returns nil when qlfile does not exist"
     (with-tmp-directory (tmp)
-      (ok (null (local-project-paths-from-registry-conf tmp)))))
+      (ok (null (local-project-paths tmp)))))
 
-  (testing "returns nil when source-registry.conf has no :tree entries"
+  (testing "returns nil when qlfile has no local entries"
     (with-tmp-directory (tmp)
-      (write-registry-conf tmp)
-      (ok (null (local-project-paths-from-registry-conf tmp)))))
+      (write-qlfile tmp "github foo/bar")
+      (ok (null (local-project-paths tmp)))))
 
-  (testing "extracts :here relative path"
+  (testing "extracts local project path"
     (with-tmp-directory (tmp)
-      ;; (:here #P"../mylib/") is relative to the .qlot dir (tmp)
-      (let ((resolved (uiop:ensure-directory-pathname
-                       (merge-pathnames #P"../mylib/" tmp))))
-        (write-registry-conf tmp `(:tree (:here #P"../mylib/")))
-        (let ((paths (local-project-paths-from-registry-conf tmp)))
+      (let ((lib-dir (merge-pathnames #P"libs/mylib/" tmp)))
+        (ensure-directories-exist lib-dir)
+        (write-qlfile tmp "local mylib ./libs/mylib/")
+        (let ((paths (local-project-paths tmp)))
           (ok (= 1 (length paths)))
-          (ok (uiop:pathname-equal resolved (first paths)))))))
+          (ok (uiop:pathname-equal lib-dir (first paths)))))))
 
-  (testing "extracts absolute pathname"
+  (testing "extracts absolute path"
     (with-tmp-directory (tmp)
-      (with-tmp-directory (local-proj)
-        (write-registry-conf tmp `(:tree ,local-proj))
-        (let ((paths (local-project-paths-from-registry-conf tmp)))
+      (with-tmp-directory (lib-dir)
+        (write-qlfile tmp (format nil "local mylib ~A" (namestring lib-dir)))
+        (let ((paths (local-project-paths tmp)))
           (ok (= 1 (length paths)))
-          (ok (uiop:pathname-equal local-proj (first paths)))))))
+          (ok (uiop:pathname-equal lib-dir (first paths)))))))
 
-  (testing "extracts multiple :tree entries"
+  (testing "extracts multiple local entries"
     (with-tmp-directory (tmp)
-      (with-tmp-directory (proj-a)
-        (with-tmp-directory (proj-b)
-          (write-registry-conf tmp
-                               `(:tree ,proj-a)
-                               `(:tree ,proj-b))
-          (let ((paths (local-project-paths-from-registry-conf tmp)))
-            (ok (= 2 (length paths))))))))
-
-  (testing "skips :directory entries (not local projects)"
-    (with-tmp-directory (tmp)
-      ;; Only :tree entries should be returned; :directory (qlot src) is skipped
-      (write-registry-conf tmp)
-      (let ((paths (local-project-paths-from-registry-conf tmp)))
-        (ok (null paths)))))
-
-  (testing "extracts :home directive path"
-    (with-tmp-directory (tmp)
-      ;; (:home #P"mylib/") represents ~/mylib/ - should be resolved
-      (write-registry-conf tmp `(:tree (:home #P"mylib/")))
-      (let ((paths (local-project-paths-from-registry-conf tmp)))
-        (ok (= 1 (length paths)))
-        ;; The resolved path should end in mylib/ under the user home
-        (ok (uiop:pathname-equal
-             (merge-pathnames #P"mylib/" (user-homedir-pathname))
-             (first paths))))))
-
-  (testing "returns nil for malformed source-registry.conf"
-    (with-tmp-directory (tmp)
-      ;; Write garbage that is not valid s-expression
-      (let ((conf-file (merge-pathnames #P"source-registry.conf" tmp)))
-        (with-open-file (out conf-file
-                             :direction :output
-                             :if-exists :supersede
-                             :if-does-not-exist :create)
-          (write-string "this is not valid ( lisp" out)))
-      (ok (null (local-project-paths-from-registry-conf tmp)))))
-
-  (testing "returns nil for empty source-registry.conf"
-    (with-tmp-directory (tmp)
-      (let ((conf-file (merge-pathnames #P"source-registry.conf" tmp)))
-        (with-open-file (out conf-file
-                             :direction :output
-                             :if-exists :supersede
-                             :if-does-not-exist :create)
-          ;; Write empty file
-          ))
-      (ok (null (local-project-paths-from-registry-conf tmp)))))
+      (let ((lib-a (merge-pathnames #P"libs/a/" tmp))
+            (lib-b (merge-pathnames #P"libs/b/" tmp)))
+        (ensure-directories-exist lib-a)
+        (ensure-directories-exist lib-b)
+        (write-qlfile tmp
+                      "local a ./libs/a/"
+                      "github foo/bar"
+                      "local b ./libs/b/")
+        (let ((paths (local-project-paths tmp)))
+          (ok (= 2 (length paths)))))))
 
   (testing "returned paths are directory pathnames"
     (with-tmp-directory (tmp)
-      (with-tmp-directory (local-proj)
-        (write-registry-conf tmp `(:tree ,local-proj))
-        (let ((paths (local-project-paths-from-registry-conf tmp)))
+      (let ((lib-dir (merge-pathnames #P"libs/mylib/" tmp)))
+        (ensure-directories-exist lib-dir)
+        (write-qlfile tmp "local mylib ./libs/mylib/")
+        (let ((paths (local-project-paths tmp)))
           (ok (= 1 (length paths)))
-          ;; Must be a directory pathname (trailing slash)
           (ok (uiop:directory-pathname-p (first paths))))))))
 
 (deftest create-local-project-symlinks-tests

--- a/tests/bundle.lisp
+++ b/tests/bundle.lisp
@@ -2,7 +2,10 @@
   (:use #:cl
         #:rove)
   (:import-from #:qlot/bundle
-                #:local-project-paths-from-registry-conf)
+                #:local-project-paths-from-registry-conf
+                #:create-local-project-symlinks)
+  (:import-from #:qlot/cache
+                #:symlink-p)
   (:import-from #:qlot/utils/tmp
                 #:with-tmp-directory))
 (in-package #:qlot-tests/bundle)
@@ -110,3 +113,123 @@
           (ok (= 1 (length paths)))
           ;; Must be a directory pathname (trailing slash)
           (ok (uiop:directory-pathname-p (first paths))))))))
+
+(deftest create-local-project-symlinks-tests
+  (testing "no-op with empty local project list"
+    (with-tmp-directory (bundle-dir)
+      (ensure-directories-exist (merge-pathnames #P"local-projects/" bundle-dir))
+      (ok (null (create-local-project-symlinks '() bundle-dir)))))
+
+  (testing "creates symlink named after local project directory"
+    (with-tmp-directory (bundle-dir)
+      (with-tmp-directory (proj)
+        (ensure-directories-exist (merge-pathnames #P"local-projects/" bundle-dir))
+        (create-local-project-symlinks (list proj) bundle-dir)
+        (let* ((proj-name (car (last (pathname-directory proj))))
+               (link (merge-pathnames (format nil "local-projects/~A" proj-name)
+                                      bundle-dir)))
+          (ok (symlink-p link))))))
+
+  (testing "symlink target resolves to the actual project directory"
+    (with-tmp-directory (bundle-dir)
+      (with-tmp-directory (proj)
+        (ensure-directories-exist (merge-pathnames #P"local-projects/" bundle-dir))
+        (create-local-project-symlinks (list proj) bundle-dir)
+        (let* ((proj-name (car (last (pathname-directory proj))))
+               (link (merge-pathnames (format nil "local-projects/~A" proj-name)
+                                      bundle-dir)))
+          ;; truename through the symlink should resolve to the actual dir
+          (ok (uiop:pathname-equal (uiop:ensure-directory-pathname (truename link))
+                                   proj))))))
+
+  (testing "creates symlinks for multiple local projects"
+    (with-tmp-directory (bundle-dir)
+      (with-tmp-directory (proj-a)
+        (with-tmp-directory (proj-b)
+          (ensure-directories-exist (merge-pathnames #P"local-projects/" bundle-dir))
+          (create-local-project-symlinks (list proj-a proj-b) bundle-dir)
+          (let* ((name-a (car (last (pathname-directory proj-a))))
+                 (name-b (car (last (pathname-directory proj-b))))
+                 (link-a (merge-pathnames (format nil "local-projects/~A" name-a) bundle-dir))
+                 (link-b (merge-pathnames (format nil "local-projects/~A" name-b) bundle-dir)))
+            (ok (symlink-p link-a))
+            (ok (symlink-p link-b)))))))
+
+  (testing "is idempotent when called twice"
+    (with-tmp-directory (bundle-dir)
+      (with-tmp-directory (proj)
+        (ensure-directories-exist (merge-pathnames #P"local-projects/" bundle-dir))
+        (create-local-project-symlinks (list proj) bundle-dir)
+        ;; Second call should not signal an error
+        (let ((errored nil))
+          (handler-case
+              (create-local-project-symlinks (list proj) bundle-dir)
+            (error (c)
+              (declare (ignore c))
+              (setf errored t)))
+          (ok (not errored) "second call does not error"))
+        (let* ((proj-name (car (last (pathname-directory proj))))
+               (link (merge-pathnames (format nil "local-projects/~A" proj-name)
+                                      bundle-dir)))
+          (ok (symlink-p link))))))
+
+  (testing "skips non-existent local project paths"
+    (with-tmp-directory (bundle-dir)
+      (ensure-directories-exist (merge-pathnames #P"local-projects/" bundle-dir))
+      (let ((nonexistent #P"/tmp/does-not-exist-qlot-test/"))
+        (ok (null (create-local-project-symlinks (list nonexistent) bundle-dir)))
+        ;; No symlink should have been created
+        (ok (null (uiop:directory-files (merge-pathnames #P"local-projects/" bundle-dir)))))))
+
+  (testing "creates local-projects/ subdirectory when it does not exist"
+    (with-tmp-directory (bundle-dir)
+      (with-tmp-directory (proj)
+        ;; Intentionally do NOT create local-projects/ beforehand
+        (create-local-project-symlinks (list proj) bundle-dir)
+        (let* ((proj-name (car (last (pathname-directory proj))))
+               (link (merge-pathnames (format nil "local-projects/~A" proj-name)
+                                      bundle-dir)))
+          (ok (uiop:directory-exists-p (merge-pathnames #P"local-projects/" bundle-dir))
+              "local-projects/ directory was created")
+          (ok (symlink-p link))))))
+
+  (testing "overwrites existing non-symlink file at symlink location"
+    (with-tmp-directory (bundle-dir)
+      (with-tmp-directory (proj)
+        (ensure-directories-exist (merge-pathnames #P"local-projects/" bundle-dir))
+        (let* ((proj-name (car (last (pathname-directory proj))))
+               (link-path (merge-pathnames (format nil "local-projects/~A" proj-name)
+                                           bundle-dir)))
+          ;; Place a regular file where the symlink should go
+          (with-open-file (out link-path
+                               :direction :output
+                               :if-does-not-exist :create)
+            (write-string "placeholder" out))
+          (ok (uiop:file-exists-p link-path) "precondition: regular file exists")
+          ;; Should replace the file with a symlink
+          (create-local-project-symlinks (list proj) bundle-dir)
+          (ok (symlink-p link-path)
+              "regular file replaced by symlink")
+          (ok (uiop:pathname-equal (uiop:ensure-directory-pathname (truename link-path))
+                                   proj)
+              "symlink points to correct target")))))
+
+  (testing "stub returning nil would fail — symlink must actually exist"
+    ;; This test guards against a trivial stub implementation.
+    ;; It verifies the symlink is a real filesystem entry, not just a return value check.
+    (with-tmp-directory (bundle-dir)
+      (with-tmp-directory (proj)
+        (ensure-directories-exist (merge-pathnames #P"local-projects/" bundle-dir))
+        (create-local-project-symlinks (list proj) bundle-dir)
+        (let* ((proj-name (car (last (pathname-directory proj))))
+               (link (merge-pathnames (format nil "local-projects/~A" proj-name)
+                                      bundle-dir)))
+          ;; Verify the symlink exists as an actual filesystem entry
+          (ok (symlink-p link) "symlink exists on disk")
+          ;; Verify we can list it in the directory
+          (let ((entries (uiop:subdirectories (merge-pathnames #P"local-projects/" bundle-dir))))
+            (ok (<= 1 (length entries))
+                "at least one entry in local-projects/"))
+          ;; Verify reading through the symlink works
+          (ok (uiop:directory-exists-p link)
+              "symlink target is accessible as directory"))))))

--- a/tests/data/qlfile5
+++ b/tests/data/qlfile5
@@ -2,5 +2,5 @@ dist ultralisp http://dist.ultralisp.org/ultralisp.txt
 git ironclad https://github.com/sharplispers/ironclad
 ql cl-ppcre :latest
 github fukamachi/lsx
-ultralisp fukamachi-lack :latest
+ultralisp fukamachi-quri :latest
 ql mito :upstream

--- a/tests/data/qlfile5.lock
+++ b/tests/data/qlfile5.lock
@@ -18,9 +18,9 @@
  (:class qlot.source.github:source-github
   :initargs (:project-name "lsx" :repos "fukamachi/lsx" :ref nil :branch nil :tag nil)
   :version "github-7c7c00ddd125810a67bee18534d34b7a6fc84a0a"))
-("fukamachi-lack" .
+("fukamachi-quri" .
  (:class qlot.source.ultralisp:source-ultralisp
-  :initargs (:project-name "fukamachi-lack" :%version :latest)
+  :initargs (:project-name "fukamachi-quri" :%version :latest)
   :version "ultralisp-20190904101505"))
 ("mito" .
  (:class qlot/source/ql:source-ql-upstream

--- a/tests/install.lisp
+++ b/tests/install.lisp
@@ -39,7 +39,7 @@
                        "ironclad"
                        "cl-ppcre"
                        "lsx"
-                       "fukamachi-lack"
+                       "fukamachi-quri"
                        "mito")
                      :test 'string=)
           "dists are installed")
@@ -54,7 +54,7 @@
         (ok (equal (aget data "version") "ql-2018-08-31")))
       (let ((data (parse-distinfo-file (merge-pathnames "dists/lsx/distinfo.txt" qlhome))))
         (ok (equal (aget data "version") "github-7c7c00ddd125810a67bee18534d34b7a6fc84a0a")))
-      (let ((data (parse-distinfo-file (merge-pathnames "dists/fukamachi-lack/distinfo.txt" qlhome))))
+      (let ((data (parse-distinfo-file (merge-pathnames "dists/fukamachi-quri/distinfo.txt" qlhome))))
         (ok (equal (aget data "version") "ultralisp-20190904101505")))
       (let ((data (parse-distinfo-file (merge-pathnames "dists/mito/distinfo.txt" qlhome))))
         (ok (equal (aget data "version") "ql-upstream-8c795b7b4de7dc635f1d2442ef1faf8f23d283e6")))
@@ -68,18 +68,18 @@
       (dolist (dist-name '("ironclad"
                            "cl-ppcre"
                            "lsx"
-                           "fukamachi-lack"
+                           "fukamachi-quri"
                            "mito"))
         (ok (uiop:directory-exists-p
               (merge-pathnames (format nil "dists/~A/software/" dist-name)
                                qlhome))))
 
-      (let ((data (parse-distinfo-file (merge-pathnames "dists/fukamachi-lack/distinfo.txt" qlhome))))
+      (let ((data (parse-distinfo-file (merge-pathnames "dists/fukamachi-quri/distinfo.txt" qlhome))))
         (ok (equal (aget data "version") "ultralisp-20190904101505")))
 
       (update-qlfile qlfile
                      :quicklisp-home qlhome
-                     :projects '("fukamachi-lack"))
+                     :projects '("fukamachi-quri"))
 
       (let ((data (parse-distinfo-file (merge-pathnames "dists/lsx/distinfo.txt" qlhome))))
         (ok (equal (aget data "version") "github-7c7c00ddd125810a67bee18534d34b7a6fc84a0a")))
@@ -98,7 +98,7 @@
         (ok (equal (aget data "version") "ql-2018-08-31")))
       (let ((data (parse-distinfo-file (merge-pathnames "dists/lsx/distinfo.txt" qlhome))))
         (ng (equal (aget data "version") "github-7c7c00ddd125810a67bee18534d34b7a6fc84a0a")))
-      (let ((data (parse-distinfo-file (merge-pathnames "dists/fukamachi-lack/distinfo.txt" qlhome))))
+      (let ((data (parse-distinfo-file (merge-pathnames "dists/fukamachi-quri/distinfo.txt" qlhome))))
         (ng (equal (aget data "version") "ultralisp-20190904101505")))
       (let ((data (parse-distinfo-file (merge-pathnames "dists/mito/distinfo.txt" qlhome))))
         (ok (equal (aget data "version") "ql-upstream-8c795b7b4de7dc635f1d2442ef1faf8f23d283e6"))))))


### PR DESCRIPTION
## What

Fix `qlot bundle` to properly handle locally added projects:

- Parse the qlfile to find local project paths, include them in the ASDF source registry during bundling, and pass them to the child process for dependency collection — so transitive Quicklisp dependencies of local projects are found and bundled
- Create symlinks in `.bundle-libs/local-projects/` pointing to actual local project directories (instead of leaving an empty directory with only a `.keep` file)
- Replace `fukamachi-lack` with `fukamachi-quri` in test fixtures to fix CI failures caused by lack's Ultralisp build error

## Why

When a project uses locally added projects (via `local` in qlfile) and the main `.asd` includes them in `:depends-on`, `qlot bundle` did not install the local project's transitive dependencies into `.bundle-libs/`. This happened because:

1. The dependency collection child process only walked the project root for `.asd` files — local project directories (which may be outside the project root) were never scanned
2. The ASDF source registry used during bundling only included `(:tree project-root)`, not the local project paths
3. `.bundle-libs/local-projects/` was created as an empty directory with a `.keep` file but no symlinks to actual local projects

## Limitations

- Two local projects with the same directory basename will collide (second symlink overwrites the first). This is an edge case unlikely in practice.