### PR TITLE
Skip dot-directories when scanning local-projects for .asd files

### DIFF
--- a/quicklisp-client/quicklisp/bundle-template.lisp
+++ b/quicklisp-client/quicklisp/bundle-template.lisp
@@ -34,8 +34,19 @@
                                    (file-lines data-source))))
 
            (local-projects-system-pathnames (data-source)
-             (let ((files (directory (merge-pathnames "**/*.asd"
-                                                      data-source))))
+             (let ((files '()))
+               (labels ((dotdir-p (dir)
+                          (let ((name (first (last (pathname-directory dir)))))
+                            (and (stringp name)
+                                 (< 0 (length name))
+                                 (char= (aref name 0) #\.))))
+                        (walk (dir)
+                          (unless (dotdir-p dir)
+                            (dolist (file (uiop:directory-files dir "*.asd"))
+                              (push file files))
+                            (dolist (subdir (uiop:subdirectories dir))
+                              (walk subdir)))))
+                 (walk data-source))
                (stable-sort (sort files #'string< :key #'namestring)
                             #'<
                             :key (lambda (file)


### PR DESCRIPTION
## What
Replace the `(directory "**/*.asd")` glob in `bundle-template.lisp` with a recursive walk that skips directories whose names start with `.`.

## Why
The old implementation traversed all subdirectories including `.claude`, `.git`, `.jj`, `.cache`, etc. Projects with large worktree copies under `.claude/worktrees` paid a significant cost scanning thousands of irrelevant Lisp files on every local-projects lookup. Dot-directories are convention-excluded from project content (the same logic already exists in `quicklisp/local-projects.lisp`), so skipping them is safe and consistent.