### PR TITLE
Fix SB-POSIX:RMDIR "Directory not empty (66)"

### DIFF
--- a/src/cache.lisp
+++ b/src/cache.lisp
@@ -54,7 +54,8 @@
            #:restore-release-from-cache
            #:save-release-to-cache
            #:symlink-p
-           #:create-symlink))
+           #:create-symlink
+           #:remove-symlinks-in-directory))
 (in-package #:qlot/cache)
 
 (defvar *cache-directory*
@@ -385,6 +386,30 @@ with trailing slashes are handled correctly."
     ((probe-file path)
      (uiop:delete-file-if-exists path))
     (t nil)))
+
+(defun remove-symlinks-in-directory (directory)
+  "Remove all top-level symbolic links in DIRECTORY.
+
+Some Lisp/OS combinations (notably SBCL on macOS) silently drop
+symlinks-to-directories and dangling symlinks from `(directory ...
+:resolve-symlinks nil)`, so Quicklisp's delete-directory-tree leaves
+them behind and rmdir then fails with ENOTEMPTY. Enumerate via `find`
+with -print0 instead, which sees them reliably and handles paths with
+embedded newlines."
+  (when (uiop:directory-exists-p directory)
+    (let* ((dir (uiop:native-namestring directory))
+           (output (handler-case
+                       (uiop:run-program
+                        (list "find" dir "-maxdepth" "1" "-type" "l" "-print0")
+                        :output :string
+                        :error-output nil
+                        :ignore-error-status t)
+                     (error () ""))))
+      (dolist (path (uiop:split-string output :separator (string (code-char 0))))
+        (when (and (string/= path "") (string/= path dir))
+          (handler-case (delete-file path)
+            (error (e)
+              (warn "Failed to remove symlink ~S: ~A" path e))))))))
 
 (defun make-directory-read-only (path)
   #+sbcl

--- a/src/install.lisp
+++ b/src/install.lisp
@@ -182,7 +182,6 @@ Should be called after Quicklisp is loaded."
           (release-sym (uiop:intern* '#:release '#:ql-dist))
           (dist-class-sym (uiop:intern* '#:dist '#:ql-dist))
           (base-directory-sym (uiop:intern* '#:base-directory '#:ql-dist))
-          (provided-releases-sym (uiop:intern* '#:provided-releases '#:ql-dist))
           (local-archive-file-sym (uiop:intern* '#:local-archive-file '#:ql-dist)))
       (eval
        `(defmethod ,install-sym :around ((release ,release-sym))
@@ -213,19 +212,18 @@ Should be called after Quicklisp is loaded."
           (call-next-method)))
       ;; Patch dist-level uninstall to handle symlinked release directories.
       ;; When a dist is uninstalled, delete-directory-tree is called on the entire
-      ;; dist directory. Symlinks in software/ would cause rmdir to fail with ENOTDIR
-      ;; and would also follow symlinks into the shared cache directory.
+      ;; dist directory. Symlinks in software/ would otherwise cause rmdir to fail
+      ;; with ENOTEMPTY (SBCL's (directory ... :resolve-symlinks nil) does not
+      ;; enumerate symlinks-to-directories on macOS) and would have followed
+      ;; symlinks into the shared cache directory via truename.
+      ;;
+      ;; We unconditionally sweep software/ for symlinks (including orphans not
+      ;; tracked in provided-releases, which accumulate when the dist metadata
+      ;; gets out of sync with the on-disk state).
       (eval
        `(defmethod ,uninstall-sym :around ((dist ,dist-class-sym))
-          (dolist (release (handler-case (,provided-releases-sym dist)
-                             (error (e)
-                               (warn "Failed to enumerate releases for dist uninstall: ~A" e)
-                               nil)))
-            (let* ((base-dir (,base-directory-sym release))
-                   (path (string-right-trim "/" (namestring base-dir))))
-              (when (qlot/cache:symlink-p path)
-                (delete-file (parse-namestring path))
-                (ensure-directories-exist base-dir))))
+          (let ((software-dir (merge-pathnames "software/" (,base-directory-sym dist))))
+            (qlot/cache:remove-symlinks-in-directory software-dir))
           (call-next-method))))
     (setf *release-cache-method-loaded* t)))
 

--- a/tests/cache.lisp
+++ b/tests/cache.lisp
@@ -495,6 +495,110 @@
             "remove-path should return NIL for nonexistent paths")))))
 
 ;;; ==========================================================================
+;;; Tests for remove-symlinks-in-directory
+;;; ==========================================================================
+
+(deftest test-remove-symlinks-in-directory-removes-symlinks
+  (testing "removes symlinks-to-directories that SBCL's directory misses"
+    (with-tmp-directory (tmp)
+      (let ((target1 (merge-pathnames "cache/target1/" tmp))
+            (target2 (merge-pathnames "cache/target2/" tmp))
+            (software (merge-pathnames "software/" tmp)))
+        (ensure-directories-exist (merge-pathnames "file.txt" target1))
+        (ensure-directories-exist (merge-pathnames "file.txt" target2))
+        (with-open-file (s (merge-pathnames "file.txt" target1)
+                           :direction :output :if-does-not-exist :create)
+          (write-line "t1" s))
+        (with-open-file (s (merge-pathnames "file.txt" target2)
+                           :direction :output :if-does-not-exist :create)
+          (write-line "t2" s))
+        (ensure-directories-exist software)
+        (make-symlink target1 (merge-pathnames "link1" software))
+        (make-symlink target2 (merge-pathnames "link2" software))
+        (ok (qlot/cache::symlink-p (merge-pathnames "link1" software))
+            "link1 should be a symlink before removal")
+        (ok (qlot/cache::symlink-p (merge-pathnames "link2" software))
+            "link2 should be a symlink before removal")
+        (qlot/cache::remove-symlinks-in-directory software)
+        (ng (probe-file (merge-pathnames "link1" software))
+            "link1 should be removed")
+        (ng (probe-file (merge-pathnames "link2" software))
+            "link2 should be removed")
+        ;; After removal, rmdir on software/ must succeed — this is the
+        ;; concrete reproducer for the ENOTEMPTY (errno 66) failure mode.
+        (uiop:delete-empty-directory software)
+        (ng (uiop:directory-exists-p software)
+            "software/ should be removable once symlinks are gone")
+        ;; Cache targets must remain untouched (no symlink-following deletion).
+        (ok (uiop:file-exists-p (merge-pathnames "file.txt" target1))
+            "Cache target1 file must NOT be deleted")
+        (ok (uiop:file-exists-p (merge-pathnames "file.txt" target2))
+            "Cache target2 file must NOT be deleted")))))
+
+(deftest test-remove-symlinks-in-directory-preserves-non-symlinks
+  (testing "preserves regular files and real subdirectories"
+    (with-tmp-directory (tmp)
+      (let ((target (merge-pathnames "cache/target/" tmp))
+            (software (merge-pathnames "software/" tmp)))
+        (ensure-directories-exist target)
+        (ensure-directories-exist (merge-pathnames "real-subdir/" software))
+        (with-open-file (s (merge-pathnames "regular.txt" software)
+                           :direction :output :if-does-not-exist :create)
+          (write-line "keep me" s))
+        (make-symlink target (merge-pathnames "stale-link" software))
+        (qlot/cache::remove-symlinks-in-directory software)
+        (ng (probe-file (merge-pathnames "stale-link" software))
+            "Symlink should be removed")
+        (ok (uiop:file-exists-p (merge-pathnames "regular.txt" software))
+            "Regular file should be preserved")
+        (ok (uiop:directory-exists-p (merge-pathnames "real-subdir/" software))
+            "Real subdirectory should be preserved")))))
+
+(deftest test-remove-symlinks-in-directory-nonexistent
+  (testing "silently succeeds when directory does not exist"
+    (with-tmp-directory (tmp)
+      (let ((missing (merge-pathnames "does-not-exist/" tmp)))
+        ;; Must not signal — orphan dists may have been partially deleted already.
+        (ok (null (qlot/cache::remove-symlinks-in-directory missing))
+            "Should return NIL without erroring on missing directory")))))
+
+(deftest test-remove-symlinks-in-directory-empty
+  (testing "no-op on empty directory"
+    (with-tmp-directory (tmp)
+      (let ((empty (merge-pathnames "empty/" tmp)))
+        (ensure-directories-exist empty)
+        (qlot/cache::remove-symlinks-in-directory empty)
+        (ok (uiop:directory-exists-p empty)
+            "Empty directory should still exist")))))
+
+(deftest test-remove-symlinks-in-directory-broken-symlinks
+  (testing "removes broken symlinks (the actual SBCL+macOS reproducer)"
+    ;; The user-reported failure mode was an orphan dist whose software/ contained
+    ;; symlinks whose targets had been wiped from ~/.cache/qlot/. On SBCL+macOS,
+    ;; (uiop:subdirectories software/) returns NIL for that state, so Quicklisp's
+    ;; delete-directory-tree silently leaves the broken symlinks and rmdir fails
+    ;; with ENOTEMPTY. This test locks down the workaround for that exact state.
+    (with-tmp-directory (tmp)
+      (let ((software (merge-pathnames "software/" tmp))
+            (gone (merge-pathnames "cache-was-wiped/" tmp)))
+        (ensure-directories-exist software)
+        (make-symlink gone (merge-pathnames "broken1" software))
+        (make-symlink gone (merge-pathnames "broken2" software))
+        ;; Sanity-check the bug we are working around: SBCL's standard
+        ;; enumeration sees nothing here even though `ls` would.
+        #+sbcl
+        (ok (null (uiop:subdirectories software))
+            "Sanity: SBCL uiop:subdirectories misses broken symlinks")
+        (qlot/cache::remove-symlinks-in-directory software)
+        (ng (probe-file (merge-pathnames "broken1" software))
+            "broken1 should be removed")
+        (ng (probe-file (merge-pathnames "broken2" software))
+            "broken2 should be removed")
+        (uiop:delete-empty-directory software)
+        (ng (uiop:directory-exists-p software)
+            "software/ should be removable once broken symlinks are gone")))))
+
+;;; ==========================================================================
 ;;; Tests for save-to-cache with symlinks
 ;;; ==========================================================================
 


### PR DESCRIPTION
qlot install crashes with SB-POSIX:RMDIR "Directory not empty (66)" when an orphan dist (no longer referenced by qlfile) has accumulated symlinks under .qlot/dists/<dist>/software/ from earlier release-level cache restores.

On SBCL on macOS, (directory pattern :resolve-symlinks nil) silently omits symlinks-to-directories (and dangling symlinks), so Quicklisp's delete-directory-tree never sees the leftover symlinks, treats software/ as empty, and the final rmdir then fails with ENOTEMPTY.