### PR TITLE
Scrub credentials from URLs in shell logs and error reports

### DIFF
--- a/qlot-tests.asd
+++ b/qlot-tests.asd
@@ -22,6 +22,7 @@
                "qlot-tests/utils"
                "qlot-tests/utils/ql"
                "qlot-tests/utils/asdf"
+               "qlot-tests/shell"
                "qlot-tests/bundle"
                "qlot-tests/cli")
   :perform (test-op (op c) (symbol-call :rove :run c)))

--- a/src/utils.lisp
+++ b/src/utils.lisp
@@ -14,6 +14,7 @@
            #:merge-hash-tables
            #:octets-stream-to-string
            #:https-of
+           #:scrub-url-credentials
            #:ensure-list
            #:ensure-cons
            #:ensure-package-loaded))
@@ -120,6 +121,24 @@ with the same key."
            (<= 7 (length url))
            (search "http://" url :end2 7))
       (format nil "https://~A" (subseq url 7))
+      url))
+
+(defun scrub-url-credentials (url)
+  (if (stringp url)
+      (let ((scheme-end (search "://" url)))
+        (if scheme-end
+            (let* ((authority-start (+ scheme-end 3))
+                   (authority-end (or (position #\/ url :start authority-start)
+                                      (length url)))
+                   (userinfo-end (position #\@ url
+                                           :start authority-start
+                                           :end authority-end)))
+              (if userinfo-end
+                  (concatenate 'string
+                               (subseq url 0 authority-start)
+                               (subseq url (1+ userinfo-end)))
+                  url))
+            url))
       url))
 
 (defun ensure-list (object)

--- a/src/utils.lisp
+++ b/src/utils.lisp
@@ -130,9 +130,14 @@ with the same key."
             (let* ((authority-start (+ scheme-end 3))
                    (authority-end (or (position #\/ url :start authority-start)
                                       (length url)))
+                   ;; Strip up to the LAST @ within the authority so a
+                   ;; literal @ in the userinfo (e.g. a token or password
+                   ;; containing @) is fully removed rather than leaking a
+                   ;; residue past the first @.
                    (userinfo-end (position #\@ url
                                            :start authority-start
-                                           :end authority-end)))
+                                           :end authority-end
+                                           :from-end t)))
               (if userinfo-end
                   (concatenate 'string
                                (subseq url 0 authority-start)

--- a/src/utils/shell.lisp
+++ b/src/utils/shell.lisp
@@ -3,6 +3,8 @@
   (:import-from #:qlot/logger
                 #:*debug*
                 #:debug-log)
+  (:import-from #:qlot/utils
+                #:scrub-url-credentials)
   (:export #:safety-shell-command
            #:shell-command-error
            #:shell-command-error-output
@@ -32,26 +34,30 @@
 
 (defun safety-shell-command (program args &key (output :string))
   (setf args (mapcar #'princ-to-string args))
-  (debug-log "Running shell command: ~A~{ ~S~}" program args)
-  (uiop:with-temporary-file (:pathname stderr-file
-                             :stream stderr
-                             :direction :io)
-    (handler-case
-        (uiop:run-program (cons program args)
-                          :input :interactive
-                          :output output
-                          :error-output (if *debug*
-                                            :interactive
-                                            stderr-file))
-      (uiop/run-program:subprocess-error (e)
-        (error 'shell-command-error
-               :command (cons program args)
-               :code (uiop/run-program:subprocess-error-code e)
-               :stderr (uiop:slurp-stream-string stderr))))))
+  (let ((display-args (mapcar #'scrub-url-credentials args)))
+    (debug-log "Running shell command: ~A~{ ~S~}" program display-args)
+    (uiop:with-temporary-file (:pathname stderr-file
+                                         :stream stderr
+                                         :direction :io)
+      (handler-case
+          (uiop:run-program (cons program args)
+                            :input :interactive
+                            :output output
+                            :error-output (if *debug*
+                                              :interactive
+                                              stderr-file))
+        (uiop/run-program:subprocess-error (e)
+          (error 'shell-command-error
+                 :command (cons program display-args)
+                 :code (uiop/run-program:subprocess-error-code e)
+                 :stderr (scrub-url-credentials
+                          (uiop:slurp-stream-string stderr))))))))
 
 (defun safety-background-command (program args &key input output)
   (setf args (mapcar #'princ-to-string args))
-  (debug-log "Running a background command: ~A~{ ~S~}" program args)
+  (debug-log "Running a background command: ~A~{ ~S~}"
+             program
+             (mapcar #'scrub-url-credentials args))
   (uiop:launch-program (cons program args)
                        :input input
                        :output output

--- a/tests/shell.lisp
+++ b/tests/shell.lisp
@@ -1,0 +1,33 @@
+(defpackage #:qlot-tests/shell
+  (:use #:cl
+        #:rove)
+  (:import-from #:qlot/utils/shell
+                #:safety-shell-command
+                #:shell-command-error)
+  (:import-from #:qlot/logger
+                #:*debug*
+                #:*logger-debug-stream*))
+(in-package #:qlot-tests/shell)
+
+(deftest safety-shell-command-scrubs-token-from-error
+  (let ((err (handler-case
+                 (safety-shell-command "git" '("ls-remote"
+                                               "https://x-access-token:SECRETTOKEN@nonexistent.invalid/foo/bar"))
+               (shell-command-error (e) e))))
+    (ok (typep err 'shell-command-error)
+        "shell-command-error is signaled")
+    (ng (search "SECRETTOKEN" (princ-to-string err))
+        "token must not appear in error message")
+    (ok (search "nonexistent.invalid" (princ-to-string err))
+        "host must appear in error message")))
+
+(deftest safety-shell-command-scrubs-token-from-debug-log
+  (let ((log-stream (make-string-output-stream)))
+    (let ((*debug* t)
+          (*logger-debug-stream* log-stream))
+      (handler-case
+          (safety-shell-command "git" '("ls-remote"
+                                        "https://x-access-token:SECRETTOKEN@nonexistent.invalid/foo/bar"))
+        (shell-command-error () nil)))
+    (ng (search "SECRETTOKEN" (get-output-stream-string log-stream))
+        "token must not appear in debug log")))

--- a/tests/utils.lisp
+++ b/tests/utils.lisp
@@ -21,3 +21,28 @@
              '("abc")))
   (ok (equal (split-with #\Space "a b c " :limit 2)
              '("a" "b c "))))
+
+(deftest scrub-url-credentials-tests
+  ;; Credentialed forms — userinfo must be stripped
+  (ok (equal (qlot/utils::scrub-url-credentials "https://x-access-token:TOKEN@github.com/foo/bar")
+             "https://github.com/foo/bar")
+      "token:password form stripped")
+  (ok (equal (qlot/utils::scrub-url-credentials "https://ghp_secret@github.com/foo/bar")
+             "https://github.com/foo/bar")
+      "bare-token userinfo (no colon) stripped")
+  (ok (equal (qlot/utils::scrub-url-credentials "https://user:pass@gitlab.com/a/b.git")
+             "https://gitlab.com/a/b.git")
+      "user:pass form stripped")
+  ;; Non-credentialed inputs — must pass through unchanged
+  (ok (equal (qlot/utils::scrub-url-credentials "https://github.com/foo/bar")
+             "https://github.com/foo/bar")
+      "URL without credentials unchanged")
+  (ok (equal (qlot/utils::scrub-url-credentials "git@github.com:foo/bar")
+             "git@github.com:foo/bar")
+      "SCP form (no ://) unchanged")
+  (ok (null (qlot/utils::scrub-url-credentials nil))
+      "nil passes through as NIL")
+  ;; @ outside authority must not be stripped
+  (ok (equal (qlot/utils::scrub-url-credentials "https://github.com/foo/bar?e=a@b.com")
+             "https://github.com/foo/bar?e=a@b.com")
+      "@ in query string not stripped"))

--- a/tests/utils.lisp
+++ b/tests/utils.lisp
@@ -45,4 +45,9 @@
   ;; @ outside authority must not be stripped
   (ok (equal (qlot/utils::scrub-url-credentials "https://github.com/foo/bar?e=a@b.com")
              "https://github.com/foo/bar?e=a@b.com")
-      "@ in query string not stripped"))
+      "@ in query string not stripped")
+  ;; A literal @ inside the userinfo (e.g. a token containing @) must be
+  ;; fully stripped to the last @ in the authority, leaving no residue
+  (ok (equal (qlot/utils::scrub-url-credentials "https://user:p@ss@github.com/foo/bar")
+             "https://github.com/foo/bar")
+      "@ within userinfo stripped to the last authority @"))


### PR DESCRIPTION
## What
Add a `scrub-url-credentials` helper to `qlot/utils` and use it to strip embedded credentials from URLs in `safety-shell-command`'s debug log and the `shell-command-error` report.

## Why
`source-git-remote-access-url` injects `GITHUB_TOKEN` as `https://x-access-token:TOKEN@github.com/...`. That URL then leaked through the shell debug log and the `shell-command-error` `:command` slot — which the condition's `:report` prints and `git-ref` re-surfaces via `(warn (princ-to-string e))`. The scrub is display-only: `uiop:run-program` still receives the raw URL, so authentication keeps working. Userinfo is removed up to the last `@` within the authority, so a token or password containing a literal `@` leaves no residue, while an `@` in a path or query is preserved.

## Limitations
git's own subprocess stderr may still echo a URL on auth failure; this scrubs qlot's own logs and error reports, not subprocess output.