### PR TITLE
Reject dot segments in cache path keys

### DIFF
--- a/src/cache.lisp
+++ b/src/cache.lisp
@@ -255,7 +255,8 @@ release hook handles caching. Only metadata needs source-level caching."
 
 (defun split-path (path)
   (when (and path (string/= "" path))
-    (remove-if (lambda (segment) (string= segment ""))
+    (remove-if (lambda (segment)
+                 (member segment '("" "." "..") :test #'string=))
                (uiop:split-string path :separator "/"))))
 
 (defun staging-path (pathname)

--- a/tests/cache.lisp
+++ b/tests/cache.lisp
@@ -66,6 +66,18 @@
              (split-path "single")))
   (ok (null (split-path ""))))
 
+(deftest test-split-path-drops-dot-segments
+  (testing "Drops .. segments"
+    (ok (equal '("a" "b")
+               (split-path "a/../b"))
+        ".. between real segments must be dropped")
+    (ng (member ".." (split-path "../../etc/passwd") :test #'string=)
+        "no .. segment may survive a traversal-attack path"))
+  (testing "Drops . segments"
+    (ok (equal '("a" "b")
+               (split-path "a/./b"))
+        ". between real segments must be dropped")))
+
 (deftest test-url-has-credentials-p
   (testing "URLs with credentials"
     (ok (url-has-credentials-p "https://user:token@github.com/foo/bar"))


### PR DESCRIPTION
## What
Drop `..` and `.` segments in `qlot/cache::split-path`, the single choke point feeding every cache-key method.

## Why
`split-path` only filtered empty segments, so a crafted qlfile URL/path containing `..` could direct the on-disk cache path outside the cache root via `merge-pathnames` of a `:relative ".."` component. No legitimate host or path component is literally `.` or `..`, so no real cache key changes.