### PR TITLE
Fix unbound version slot on cached git :ref sources

### DIFF
--- a/src/source/git.lisp
+++ b/src/source/git.lisp
@@ -48,6 +48,22 @@
            :remote-url remote-url
            args)))
 
+(defmethod prepare-source ((source source-git))
+  ;; A ref fully determines the version (git-<ref>) with no network access,
+  ;; so bind it eagerly. distify-git is the only other place that sets the
+  ;; version, and it is skipped on a cache hit -- leaving the slot unbound
+  ;; and crashing install when something later reads it.
+  (when (and (source-git-ref source)
+             (not (slot-boundp source 'qlot/source/base::version)))
+    (setf (source-version source)
+          (concatenate 'string
+                       (source-version-prefix source)
+                       (source-git-ref source)))))
+
+(defmethod initialize-instance :after ((source source-git) &rest initargs)
+  (declare (ignore initargs))
+  (prepare-source source))
+
 (defmethod defrost-source :after ((source source-git))
   (when (slot-boundp source 'qlot/source/base::version)
     (setf (source-git-ref source)

--- a/tests/cache.lisp
+++ b/tests/cache.lisp
@@ -107,6 +107,14 @@
     (ok (equal '("git" "github.com" "user" "mylib" "abc123def456")
                (cache-key source)))))
 
+(deftest test-ref-git-source-has-version
+  ;; cache hit skips distify, so version must already be bound -- see prepare-source.
+  (let ((source (make-source :git "mylib" "https://github.com/user/mylib.git"
+                             :ref "abc123def456")))
+    (ok (equal "git-abc123def456" (source-version source)))
+    (ok (equal '("git" "github.com" "user" "mylib" "abc123def456")
+               (cache-key source)))))
+
 (deftest test-cache-key-source-github
   (let ((source (make-source :github "user/repo" :ref "abc123")))
     (setf (source-github-ref source) "abc123def456")

--- a/tests/parser.lisp
+++ b/tests/parser.lisp
@@ -14,6 +14,7 @@
                 #:defrost-source
                 #:source-git
                 #:source-git-remote-url
+                #:source-git-ref
                 #:source-ql
                 #:source-ql-upstream
                 #:source-dist
@@ -323,6 +324,34 @@
       (ok (equal (source-distribution source) "http://dist.shirakumo.org/shirakumo.txt"))
       ;; Note: distinfo URL is converted to HTTPS by parent's defrost-source :after method
       (ok (equal (source-distinfo-url source) "https://dist.shirakumo.org/shirakumo/2024-01-01/distinfo.txt")))))
+
+(deftest git-freeze-defrost-tests
+  (testing "make-source binds version eagerly for a :ref source"
+    (let ((source (make-source :git "mylib" "https://github.com/user/mylib.git"
+                               :ref "abc123def456")))
+      (ok (equal (source-version source) "git-abc123def456"))
+      (ok (equal (source-git-ref source) "abc123def456"))))
+
+  (testing "freeze/defrost round-trip keeps version and ref consistent"
+    ;; Reproduce how parse-qlfile-lock reconstructs a source: make-instance
+    ;; with the frozen :initargs (which carry :ref), then apply the frozen
+    ;; :version via defrost-source. The eager initialize-instance :after must
+    ;; agree with the defrosted value rather than fight it.
+    (let* ((source (make-source :git "mylib" "https://github.com/user/mylib.git"
+                                :ref "abc123def456"))
+           (frozen (freeze-source source))
+           (args (cdr frozen))
+           (restored (apply #'make-instance (getf args :class)
+                            :project-name (car frozen)
+                            (getf args :initargs))))
+      (setf (source-defrost-args restored)
+            (loop for (k v) on args by #'cddr
+                  unless (member k '(:class :initargs))
+                  append (list k v)))
+      (defrost-source restored)
+      (ok (equal (source-version restored) "git-abc123def456"))
+      (ok (equal (source-git-ref restored) "abc123def456"))
+      (ok (source= source restored)))))
 
 (deftest ql-dist-invalid-input-tests
   (testing "make-source errors on non-string dist-name"


### PR DESCRIPTION
A :ref source's version was only set in distify-git, which a cache hit skips, so install crashed with "slot VERSION is unbound". Bind it eagerly in prepare-source since the version (git-<ref>) needs no network.